### PR TITLE
Support Hyper-schema "encType" and "targetSchema"

### DIFF
--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -170,6 +170,7 @@ module JsonSchema
           link.parent      = schema
 
           link.description = l["description"]
+          link.enc_type    = l["encType"]
           link.href        = l["href"]
           link.method      = l["method"] ? l["method"].downcase.to_sym : nil
           link.rel         = l["rel"]
@@ -177,6 +178,11 @@ module JsonSchema
 
           if l["schema"]
             link.schema = parse_data(l["schema"], schema, "links/#{i}/schema")
+          end
+
+          if l["targetSchema"]
+            link.target_schema =
+              parse_data(l["schema"], schema, "links/#{i}/targetSchema")
           end
 
           link

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -144,7 +144,6 @@ module JsonSchema
         schema.any_of.each { |s| yielder << s }
         schema.one_of.each { |s| yielder << s }
         schema.definitions.each { |_, s| yielder << s }
-        schema.links.map { |l| l.schema }.compact.each { |s| yielder << s }
         schema.pattern_properties.each { |_, s| yielder << s }
         schema.properties.each { |_, s| yielder << s }
 
@@ -172,6 +171,12 @@ module JsonSchema
         # latter
         schema.dependencies.values.
           select { |s| s.is_a?(Schema) }.
+          each { |s| yielder << s }
+
+        # schemas contained inside hyper-schema links objects
+        schema.links.map { |l| [l.schema, l.target_schema] }.
+          flatten.
+          compact.
           each { |s| yielder << s }
       end
     end

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -283,11 +283,17 @@ module JsonSchema
 
       # schema attributes
       attr_accessor :description
+      attr_accessor :enc_type
       attr_accessor :href
       attr_accessor :method
       attr_accessor :rel
       attr_accessor :schema
+      attr_accessor :target_schema
       attr_accessor :title
+
+      def enc_type
+        @enc_type || "application/json"
+      end
     end
 
     # Media type subobject for a hyperschema.

--- a/test/data_scaffold.rb
+++ b/test/data_scaffold.rb
@@ -213,6 +213,9 @@ module DataScaffold
                   "$ref" => "#/definitions/app/definitions/name"
                 },
               }
+            },
+            "targetSchema" => {
+              "$ref" => "#/definitions/app"
             }
           ],
           "media" => {

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -148,6 +148,7 @@ describe JsonSchema::Parser do
     pointer("#/definitions/app").merge!(
       "links" => [
         "description" => "Create a new app.",
+        "encType"    => "application/x-www-form-urlencoded",
         "href" => "/apps",
         "method" => "POST",
         "rel" => "create",
@@ -157,6 +158,9 @@ describe JsonSchema::Parser do
               "$ref" => "#/definitions/app/definitions/name"
             },
           }
+        },
+        "targetSchema" => {
+          "$ref" => "#/definitions/app"
         }
       ]
     )
@@ -164,6 +168,7 @@ describe JsonSchema::Parser do
     link = schema.links[0]
     assert_equal schema, link.parent
     assert_equal "Create a new app.", link.description
+    assert_equal "application/x-www-form-urlencoded", link.enc_type
     assert_equal "/apps", link.href
     assert_equal :post, link.method
     assert_equal "create", link.rel

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -116,6 +116,13 @@ describe JsonSchema::ReferenceExpander do
     assert_equal ["string"], schema.type
   end
 
+  it "will expand hyperschema link targetSchemas" do
+    expand
+    assert_equal [], errors
+    schema = @schema.properties["app"].links[0].target_schema.properties["name"]
+    assert_equal ["string"], schema.type
+  end
+
   it "will perform multiple passes to resolve all references" do
     pointer("#/properties").merge!(
       "app0" => { "$ref" => "#/properties/app1" },


### PR DESCRIPTION
As defined in spec, `encType` continues to default to
`application/json`, but this allows other types to be specified.
