### PR TITLE
Add support for V5's "strictProperties"

### DIFF
--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -278,6 +278,7 @@ module JsonSchema
       schema.pattern_properties = validate_type(schema, [Hash], "patternProperties") || {}
       schema.properties         = validate_type(schema, [Hash], "properties") || {}
       schema.required           = validate_type(schema, [Array], "required")
+      schema.strict_properties  = validate_type(schema, BOOLEAN, "strictProperties")
 
       # validation: string
       schema.format     = validate_type(schema, [String], "format")

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -153,6 +153,8 @@ module JsonSchema
     attr_copyable :pattern_properties
     attr_copyable :properties
     attr_copyable :required
+    # warning: strictProperties is technically V5 spec (but I needed it now)
+    attr_copyable :strict_properties
 
     # validation: string
     attr_copyable :format
@@ -182,6 +184,7 @@ module JsonSchema
     attr_reader_default :min_exclusive, false
     attr_reader_default :pattern_properties, {}
     attr_reader_default :properties, {}
+    attr_reader_default :strict_properties, false
     attr_reader_default :type, []
 
     # allow booleans to be access with question mark

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -72,6 +72,7 @@ module JsonSchema
         valid = strict_and valid, validate_pattern_properties(schema, data, errors, path)
         valid = strict_and valid, validate_properties(schema, data, errors, path)
         valid = strict_and valid, validate_required(schema, data, errors, path, schema.required)
+        valid = strict_and valid, validate_strict_properties(schema, data, errors, path)
       end
 
       # validation: string
@@ -380,6 +381,19 @@ module JsonSchema
     def validate_required(schema, data, errors, path, required)
       return true if !required || required.empty?
       if (missing = required - data.keys).empty?
+        true
+      else
+        message = %{Missing required keys "#{missing.sort.join(", ")}" in object; keys are "#{data.keys.sort.join(", ")}".}
+        errors << ValidationError.new(schema, path, message)
+        false
+      end
+    end
+
+    def validate_strict_properties(schema, data, errors, path)
+      return true if !schema.strict_properties
+
+      missing = schema.properties.keys - data.keys
+      if missing.empty?
         true
       else
         message = %{Missing required keys "#{missing.sort.join(", ")}" in object; keys are "#{data.keys.sort.join(", ")}".}

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -122,6 +122,14 @@ describe JsonSchema::Parser do
     assert_equal ["null", "string"], property[1].type
   end
 
+  it "parses the strictProperties object validation" do
+    pointer("#/definitions/app").merge!(
+      "strictProperties" => true
+    )
+    schema = parse.definitions["app"]
+    assert_equal true, schema.strict_properties
+  end
+
   # couldn't think of any non-contrived examples to work with here
   it "parses the basic set of schema validations" do
     schema = parse.definitions["app"].definitions["contrived"]

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -401,6 +401,23 @@ describe JsonSchema::Validator do
       %{Missing required keys "name" in object; keys are "".}
   end
 
+  it "validates strictProperties successfully" do
+    pointer("#/definitions/app").merge!(
+      "strictProperties" => false
+    )
+    assert validate
+  end
+
+  it "validates strictProperties unsuccessfully" do
+    pointer("#/definitions/app").merge!(
+      "strictProperties" => true
+    )
+    refute validate
+    missing = @schema.properties.keys.sort - ["name"]
+    assert_includes error_messages,
+      %{Missing required keys "#{missing.join(", ")}" in object; keys are "name".}
+  end
+
   it "validates allOf" do
     pointer("#/definitions/app/definitions/contrived").merge!(
       "allOf" => [


### PR DESCRIPTION
This is only in the yet-unwritten V5 draft, but I'm bringing it for now because it makes API validation quite a bit less painful.
