### PR TITLE
Support `patternProperties` when considering non-true `additionalProperties`

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -91,6 +91,12 @@ module JsonSchema
 
       extra = data.keys - schema.properties.keys
 
+      if schema.pattern_properties
+        schema.pattern_properties.keys.each do |pattern|
+          extra -= extra.select { |k| k =~ pattern }
+        end
+      end
+
       # schema indicates that all properties not in `properties` should be
       # validated according to subschema
       if schema.additional_properties.is_a?(Schema)

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -301,9 +301,13 @@ describe JsonSchema::Validator do
 
   it "validates additionalProperties boolean unsuccessfully" do
     pointer("#/definitions/app").merge!(
-      "additionalProperties" => false
+      "additionalProperties" => false,
+      "patternProperties" => {
+        "^matches" => {}
+      }
     )
     data_sample["foo"] = "bar"
+    data_sample["matches-pattern"] = "yes!"
     refute validate
     assert_includes error_messages, %{Extra keys in object: foo.}
   end
@@ -322,9 +326,13 @@ describe JsonSchema::Validator do
     pointer("#/definitions/app").merge!(
       "additionalProperties" => {
         "type" => ["boolean"]
+      },
+      "patternProperties" => {
+        "^matches" => {}
       }
     )
     data_sample["foo"] = 4
+    data_sample["matches-pattern"] = "yes!"
     refute validate
     assert_includes error_messages,
       %{Expected data to be of type "boolean"; value was: 4.}


### PR DESCRIPTION
This makes `patternProperties` correctly interact with `additionalProperties` according to [the docs](http://jsonary.com/documentation/json-schema/?section=keywords/Object%20validation#keywords/Object%20validation/03%20-%20additionalProperties).
