### PR TITLE
Travis + bundler without Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+Gemfile.lock
 tags
 *.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+cache: bundler
+
+script: bundle exec rake
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/json_schema.gemspec
+++ b/json_schema.gemspec
@@ -11,4 +11,7 @@ Gem::Specification.new do |s|
 
   s.executables   = ["validate-schema"]
   s.files         = Dir["README.md", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
+
+  s.add_development_dependency "minitest", "~> 5.3"
+  s.add_development_dependency "rake", "~> 10.3"
 end


### PR DESCRIPTION
Activate Travis for the project. For somewhat deterministic runs, add Bundler,
but don't lock dependencies in too closely by not including a Gemfile.lock.
