### PR TITLE
Use duck typing in error classes

### DIFF
--- a/lib/commands/validate_schema.rb
+++ b/lib/commands/validate_schema.rb
@@ -73,7 +73,7 @@ module Commands
 
     # Builds a JSON Reference + message like "/path/to/file#/path/to/data".
     def map_schema_errors(file, errors)
-      JsonSchema::SchemaError.aggregate(errors).map { |m| "#{file}#{m}" }
+      errors.map { |m| "#{file}#{m}" }
     end
 
     def parse(file)

--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -35,7 +35,7 @@ module JsonSchema
     def parse!(data, parent = nil)
       schema = parse(data, parent)
       if !schema
-        raise SchemaError.aggregate(@errors).join(" ")
+        raise @errors.join(" ")
       end
       schema
     end

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -33,7 +33,7 @@ module JsonSchema
 
     def expand!(schema, options = {})
       if !expand(schema, options)
-        raise SchemaError.aggregate(@errors).join(" ")
+        raise @errors.join(" ")
       end
       true
     end

--- a/lib/json_schema/schema_error.rb
+++ b/lib/json_schema/schema_error.rb
@@ -4,18 +4,16 @@ module JsonSchema
     attr_accessor :schema
 
     def self.aggregate(errors)
-      errors.map { |e|
-        if e.is_a?(ValidationError)
-          "#{e.pointer}: failed schema #{e.schema.pointer}: #{e.message}"
-        else
-          "#{e.schema.pointer}: #{e.message}"
-        end
-      }
+      errors.map(&:to_s)
     end
 
     def initialize(schema, message)
       @schema = schema
       @message = message
+    end
+
+    def to_s
+      "#{schema.pointer}: #{message}"
     end
   end
 
@@ -29,6 +27,10 @@ module JsonSchema
 
     def pointer
       path.join("/")
+    end
+
+    def to_s
+      "#{pointer}: failed schema #{schema.pointer}: #{message}"
     end
   end
 end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -27,7 +27,7 @@ module JsonSchema
 
     def validate!(data)
       if !validate(data)
-        raise SchemaError.aggregate(@errors).join(" ")
+        raise @errors.join(" ")
       end
     end
 


### PR DESCRIPTION
Let each class decide how to describe the error, rather than forcing SchemaError
to have knowledge about another class. It also means users are free to use error
descriptions in a way that suits them, rather than having to call `aggregate` just to 
get the string description.

I've left SchemaError.aggregate in place to avoid breaking uses external uses
of it, although it no longer has much purpose, and we are pre-1.0.0, so are free to
change the API at will.
