### PR TITLE
Support for Link mediaType

### DIFF
--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -175,6 +175,7 @@ module JsonSchema
           link.method      = l["method"] ? l["method"].downcase.to_sym : nil
           link.rel         = l["rel"]
           link.title       = l["title"]
+          link.media_type  = l["mediaType"]
 
           if l["schema"]
             link.schema = parse_data(l["schema"], schema, "links/#{i}/schema")

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -289,12 +289,17 @@ module JsonSchema
       attr_accessor :href
       attr_accessor :method
       attr_accessor :rel
+      attr_accessor :media_type
       attr_accessor :schema
       attr_accessor :target_schema
       attr_accessor :title
 
       def enc_type
         @enc_type || "application/json"
+      end
+
+      def media_type
+        @media_type || "application/json"
       end
     end
 

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -160,6 +160,7 @@ describe JsonSchema::Parser do
         "href" => "/apps",
         "method" => "POST",
         "rel" => "create",
+        "mediaType" => "application/json",
         "schema" => {
           "properties" => {
             "name" => {
@@ -180,6 +181,7 @@ describe JsonSchema::Parser do
     assert_equal "/apps", link.href
     assert_equal :post, link.method
     assert_equal "create", link.rel
+    assert_equal "application/json", link.media_type
     assert_equal "#/definitions/app/definitions/name",
       link.schema.properties["name"].reference.pointer
   end


### PR DESCRIPTION
According to "JSON Hyper-Schema draft04", Link Definition Object can have "mediaType" to represent RFC2046 media type.
If not specified, the default value is "application/json"
