### PR TITLE
Look up schema URIs regardless of whether they were suffixed with '#'

### DIFF
--- a/lib/json_schema/document_store.rb
+++ b/lib/json_schema/document_store.rb
@@ -6,13 +6,16 @@ module JsonSchema
   # that have already happened and handles cyclic dependencies. Store a
   # reference to the top-level schema before doing anything else.
   class DocumentStore
+    include Enumerable
+
     def initialize
       @schema_map = {}
     end
 
     def add_schema(schema)
       raise "can't add nil URI" if schema.uri.nil?
-      @schema_map[schema.uri] = schema
+      uri = schema.uri.chomp('#')
+      @schema_map[uri] = schema
     end
 
     def each
@@ -20,6 +23,7 @@ module JsonSchema
     end
 
     def lookup_schema(uri)
+      uri = uri.chomp('#')
       @schema_map[uri]
     end
   end

--- a/test/json_schema/document_store_test.rb
+++ b/test/json_schema/document_store_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+require "json_schema"
+
+describe JsonSchema::DocumentStore do
+  before do
+    @store = JsonSchema::DocumentStore.new
+  end
+
+  it "adds and looks up a schema" do
+    schema = schema_sample("http://example.com/schema")
+    @store.add_schema(schema)
+    assert_equal schema, @store.lookup_schema(schema.uri)
+  end
+
+  it "can iterate through its schemas" do
+    uri = "http://example.com/schema"
+    schema = schema_sample(uri)
+    @store.add_schema(schema)
+    assert_equal [[uri, schema]], @store.to_a
+  end
+
+  it "can lookup a schema added with a document root sign" do
+    uri = "http://example.com/schema"
+    schema = schema_sample(uri + "#")
+    @store.add_schema(schema)
+    assert_equal schema, @store.lookup_schema(uri)
+  end
+
+  it "can lookup a schema with a document root sign" do
+    uri = "http://example.com/schema"
+    schema = schema_sample(uri)
+    @store.add_schema(schema)
+    assert_equal schema, @store.lookup_schema(uri + "#")
+  end
+
+  def schema_sample(uri)
+    schema = JsonSchema::Schema.new
+    schema.uri = uri
+    schema
+  end
+end


### PR DESCRIPTION
This is causing some occasional problems where schemas are referenced with a
trailing `#` but didn't declare themselves with one, or vice versa.

Fixes #19.

/cc @geemus
