### PR TITLE
Support date format, and raise a schema error when an unknown format is in the schema

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -14,6 +14,7 @@ which is human-readable and contains information for the developer, and a
 * `unresolved_pointer`: pointer in document couldn't be resolved
 * `scheme_not_supported`: lookup of reference over scheme specified isn't supported
 * `invalid_type`: the schema being parsed is not a valid JSON schema, because a value is the wrong type
+* `unknown_format`: the format specified is not supported by this gem
 
 ### Validation errors
 

--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -14,6 +14,7 @@ module JsonSchema
       String     => "string",
       TrueClass  => "boolean",
     }
+    FORMATS = %w{date date-time email hostname ipv4 ipv6 regex uri uuid}
 
     attr_accessor :errors
 
@@ -287,6 +288,7 @@ module JsonSchema
       schema.min_length = validate_type(schema, [Integer], "minLength")
       schema.pattern    = validate_type(schema, [String], "pattern")
       schema.pattern    = Regexp.new(schema.pattern) if schema.pattern
+      validate_format(schema, schema.format) if schema.format
 
       # hyperschema
       schema.links      = validate_type(schema, [Array], "links")
@@ -330,6 +332,13 @@ module JsonSchema
       else
         value
       end
+    end
+
+    def validate_format(schema, format)
+      return if FORMATS.include?(format)
+
+      message = %{#{format.inspect} is not a valid format, must be one of #{FORMATS.join(', ')}.}
+      @errors << SchemaError.new(schema, message, :unknown_format)
     end
   end
 end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -177,6 +177,8 @@ module JsonSchema
     def validate_format(schema, data, errors, path)
       return true unless schema.format
       valid = case schema.format
+      when "date"
+        data =~ DATE_PATTERN
       when "date-time"
         data =~ DATE_TIME_PATTERN
       when "email"
@@ -511,6 +513,8 @@ module JsonSchema
     HOSTNAME_PATTERN = /^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/
 
     DATE_TIME_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-2][0-9]:[0-5][0-9]:[0-5][0-9](Z|[\-+][0-9]{2}:[0-5][0-9])$/
+
+    DATE_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
 
     # from: http://stackoverflow.com/a/17871737
     IPV4_PATTERN = /^((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])$/

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -257,6 +257,15 @@ describe JsonSchema::Parser do
     assert_includes error_types, :unknown_type
   end
 
+  it "errors on unknown formats" do
+    schema_sample["format"] = "obscure-thing"
+    refute parse
+    assert_includes error_messages, '"obscure-thing" is not a valid format, ' \
+                                    'must be one of date, date-time, email, ' \
+                                    'hostname, ipv4, ipv6, regex, uri, uuid.'
+    assert_includes error_types, :unknown_format
+  end
+
   def error_messages
     @parser.errors.map { |e| e.message }
   end

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -506,6 +506,22 @@ describe JsonSchema::Validator do
     assert_includes error_types, :not_failed
   end
 
+  it "validates date format successfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "date"
+    )
+    data_sample["owner"] = "2014-05-13"
+    assert validate
+  end
+
+  it "validates date format unsuccessfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "date"
+    )
+    data_sample["owner"] = "13/05/2014"
+    refute validate
+  end
+
   it "validates date-time format successfully" do
     pointer("#/definitions/app/definitions/owner").merge!(
       "format" => "date-time"


### PR DESCRIPTION
At present if you accidentally use an unknown format, the lack of an `else` in the `case` [here](https://github.com/gocardless/json_schema/compare/date-format?expand=1#diff-50b1d22f09d5badf9130a7c63a618c46R179) will mean that `valid` is always `nil`, and so you always get a validation error, no matter what your input is. The real problem is in the schema.

I've also added an ISO8601 date format, cause it's pretty useful!
