### PR TITLE
Validate regular expressions as ECMA-262

### DIFF
--- a/json_schema.gemspec
+++ b/json_schema.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.executables   = ["validate-schema"]
   s.files         = Dir["README.md", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
 
+  s.add_dependency             'ecma-re-validator', '~> 0.1'
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rake", "~> 10.3"
 end

--- a/json_schema.gemspec
+++ b/json_schema.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables   = ["validate-schema"]
   s.files         = Dir["README.md", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
 
-  s.add_dependency             'ecma-re-validator', '~> 0.1'
+  s.add_development_dependency 'ecma-re-validator', '~> 0.1'
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "rake", "~> 10.3"
 end

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -1,3 +1,4 @@
+require_relative "json_schema/configuration"
 require_relative "json_schema/document_store"
 require_relative "json_schema/parser"
 require_relative "json_schema/reference_expander"
@@ -6,6 +7,14 @@ require_relative "json_schema/schema_error"
 require_relative "json_schema/validator"
 
 module JsonSchema
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
   def self.parse(data)
     parser = Parser.new
     if schema = parser.parse(data)

--- a/lib/json_schema/configuration.rb
+++ b/lib/json_schema/configuration.rb
@@ -1,0 +1,16 @@
+module JsonSchema
+  class Configuration
+    attr_reader :validate_regex_with
+
+    def validate_regex_with=(validator)
+      @validate_regex_with = validator
+    end
+
+    private
+
+    def initialize
+      @validate_regex_with = nil
+    end
+
+  end
+end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -1,4 +1,5 @@
 require "uri"
+require 'ecma-re-validator'
 
 module JsonSchema
   class Validator
@@ -444,6 +445,12 @@ module JsonSchema
 
     def validate_pattern(schema, data, errors, path)
       return true unless schema.pattern
+      unless EcmaReValidator.valid?(schema.pattern)
+        message = %{#{schema.pattern.inspect} is not an ECMA-262 regular expression.}
+        errors << ValidationError.new(schema, path, message, :pattern_failed)
+        return false
+      end
+
       if data =~ schema.pattern
         true
       else

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -1,5 +1,4 @@
 require "uri"
-require 'ecma-re-validator'
 
 module JsonSchema
   class Validator
@@ -445,11 +444,6 @@ module JsonSchema
 
     def validate_pattern(schema, data, errors, path)
       return true unless schema.pattern
-      unless EcmaReValidator.valid?(schema.pattern)
-        message = %{#{schema.pattern.inspect} is not an ECMA-262 regular expression.}
-        errors << ValidationError.new(schema, path, message, :pattern_failed)
-        return false
-      end
 
       if data =~ schema.pattern
         true

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -732,6 +732,16 @@ describe JsonSchema::Validator do
     assert_includes error_types, :pattern_failed
   end
 
+  it "validates non-ECMA-262 pattern" do
+    pointer("#/definitions/app/definitions/name").merge!(
+      "pattern" => "\\Ameow",
+    )
+    data_sample["name"] = "meow"
+    refute validate
+    assert_includes error_messages, %{/\\Ameow/ is not an ECMA-262 regular expression.}
+    assert_includes error_types, :pattern_failed
+  end
+
   it "builds appropriate JSON Pointers to bad data" do
     pointer("#/definitions/app/definitions/visibility").merge!(
       "enum" => ["private", "public"]

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -732,16 +732,6 @@ describe JsonSchema::Validator do
     assert_includes error_types, :pattern_failed
   end
 
-  it "validates non-ECMA-262 pattern" do
-    pointer("#/definitions/app/definitions/name").merge!(
-      "pattern" => "\\Ameow",
-    )
-    data_sample["name"] = "meow"
-    refute validate
-    assert_includes error_messages, %{/\\Ameow/ is not an ECMA-262 regular expression.}
-    assert_includes error_types, :pattern_failed
-  end
-
   it "builds appropriate JSON Pointers to bad data" do
     pointer("#/definitions/app/definitions/visibility").merge!(
       "enum" => ["private", "public"]


### PR DESCRIPTION
Here's the thing: JSON schema expects regular expression patterns to be [ECMA-262 compatible](http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.3).

I wrote a little gem to detect whether a given string of RegEx is valid under ECMA-262 or not. All of the heavy lifting is done by @ammar's amazing [regexp_parser](https://github.com/ammar/regexp_parser) library. The gem is simple: given a string, does it contain any non-valid syntax? If so, it fails the validation.

The goal of this PR is to minimize false Ruby-style regular expressions from slipping through while constructing JSON schemas. Although Ruby's Regexp is being used to construct the regular expressions, it's more correct to expect them to be ECMA-262 compatible. 

I am up for any and all suggestions for improving this!