### PR TITLE
Simplify `JsonSchema#inspect`

### DIFF
--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -215,9 +215,7 @@ module JsonSchema
     end
 
     def inspect
-      str = inspect_schema
-      str = JSON.pretty_generate(str).gsub(/\\?"/, '') if str.is_a?(Hash)
-      "\#<JsonSchema::Schema #{str}>"
+      "\#<JsonSchema::Schema>"
     end
 
     def inspect_schema


### PR DESCRIPTION
Unfortunately, our recursive inspect seems to cause trouble in some
cases (see interagent/committee#77). Even when it doesn't, it's quite
expensive to produce and can cause some trouble when higher level
libraries call it automatically.

This simplifies `#inspect` to produce a minimal representation. The
helper in `#inspect_schema` is still available for debugging.