### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Brandur and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/json_schema.gemspec
+++ b/json_schema.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.executables   = ["validate-schema"]
-  s.files         = Dir["README.md", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
+  s.files         = Dir["README.md", "LICENSE", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
 
   s.add_development_dependency 'ecma-re-validator', '~> 0.1'
   s.add_development_dependency "minitest", "~> 5.3"


### PR DESCRIPTION
The gemspec has the `MIT` license declared, but there is no license file. This adds a copy of the MIT license and a copyright notice.

See https://github.com/benbalter/licensee#why-not-just-look-at-the-license-field-of-insert-package-manager-here for more information.