### PR TITLE
Provide better type error messages

### DIFF
--- a/lib/json_schema/schema_error.rb
+++ b/lib/json_schema/schema_error.rb
@@ -34,4 +34,29 @@ module JsonSchema
       "#{pointer}: failed schema #{schema.pointer}: #{message}"
     end
   end
+
+  module ErrorFormatter
+    def to_list(list)
+      words_connector     = ', '
+      two_words_connector = ' or '
+      last_word_connector = ', or '
+
+      length = list.length
+      joined_list = case length
+                    when 1
+                      list[0]
+                    when 2
+                      "#{list[0]}#{two_words_connector}#{list[1]}"
+                     else
+                      "#{list[0...-1].join(words_connector)}#{last_word_connector}#{list[-1]}"
+                    end
+
+      if joined_list[0] =~ /^[aeiou]/
+        "an #{joined_list}"
+      else
+        "a #{joined_list}"
+      end
+    end
+    module_function :to_list
+  end
 end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -506,7 +506,7 @@ module JsonSchema
       if valid_types.any? { |t| data.is_a?(t) }
         true
       else
-        message = %{#{data.inspect} is not a #{schema.type.join("/")}.}
+        message = %{#{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
         errors << ValidationError.new(schema, path, message, :invalid_type)
         false
       end

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -40,7 +40,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{4 is not a object.}
+    assert_includes error_messages, %{4 is not an object.}
     assert_includes error_types, :invalid_type
   end
 
@@ -420,7 +420,7 @@ describe JsonSchema::Validator do
       "KEY" => 456
     }
     refute validate
-    assert_includes error_messages, %{456 is not a null/string.}
+    assert_includes error_messages, %{456 is not a null or string.}
     assert_includes error_types, :invalid_type
   end
 

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -44,6 +44,32 @@ describe JsonSchema::Validator do
     assert_includes error_types, :invalid_type
   end
 
+  it "provides accurate error messages for multiple type errors" do
+    pointer("#/definitions/app").merge!(
+      "type" => ["string"]
+    )
+    @data_sample = 4
+    refute validate
+    assert_includes error_messages, %{4 is not a string.}
+    assert_includes error_types, :invalid_type
+
+    pointer("#/definitions/app").merge!(
+      "type" => ["string", "null"]
+    )
+    @data_sample = 4
+    refute validate
+    assert_includes error_messages, %{4 is not a string or null.}
+    assert_includes error_types, :invalid_type
+
+    pointer("#/definitions/app").merge!(
+      "type" => ["object", "null", "string"]
+    )
+    @data_sample = 4
+    refute validate
+    assert_includes error_messages, %{4 is not an object, null, or string.}
+    assert_includes error_types, :invalid_type
+  end
+
   it "validates items with list successfully" do
     pointer("#/definitions/app/definitions/flags").merge!(
       "items" => {


### PR DESCRIPTION
Currently, when a validation fails to match one or more types, an error message like the following is returned:

```
[{\"hello\"=>{\"content\"=>\"bar\"}}] is not a object/null.
```

This PR suggests that we transforms the "a object/null" portion into something a little friendlier:

```
[{\"hello\"=>{\"content\"=>\"bar\"}}] is not an object or null.
```

For multiple errors, the output would be:

```
[{\"hello\"=>{\"content\"=>\"bar\"}}] is not an object, null, or integer.
```

The code is more or less [the same way Rails does it](https://github.com/rails/rails/blob/v3.1.1/activesupport/lib/active_support/core_ext/array/conversions.rb#L11-35).

/cc @izuzak @jasonrudolph since we'd been discussing this internally.