### PR TITLE
List which keys are erroring

### DIFF
--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -23,9 +23,6 @@ module JsonSchema
     # schema for debugging.
     attr_accessor :fragment
 
-    # An array that represents the nested path of the final JSON Pointer.
-    attr_accessor :split_pointer
-
     # Rather than a normal schema, the node may be a JSON Reference. In this
     # case, no other attributes will be filled in except for #parent.
     attr_accessor :reference
@@ -268,10 +265,6 @@ module JsonSchema
       else
         fragment
       end
-    end
-
-    def split_pointer
-      @split_pointer ||= pointer.split("/")
     end
 
     def validate(data)

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -267,6 +267,10 @@ module JsonSchema
       end
     end
 
+    def final_pointer
+      pointer.split("/").last
+    end
+
     def validate(data)
       validator = Validator.new(self)
       valid = validator.validate(data)

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -267,8 +267,8 @@ module JsonSchema
       end
     end
 
-    def final_pointer
-      pointer.split("/").last
+    def split_pointer
+      pointer.split("/")
     end
 
     def validate(data)

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -23,6 +23,9 @@ module JsonSchema
     # schema for debugging.
     attr_accessor :fragment
 
+    # An array that represents the nested path of the final JSON Pointer.
+    attr_accessor :split_pointer
+
     # Rather than a normal schema, the node may be a JSON Reference. In this
     # case, no other attributes will be filled in except for #parent.
     attr_accessor :reference
@@ -268,7 +271,7 @@ module JsonSchema
     end
 
     def split_pointer
-      pointer.split("/")
+      @split_pointer ||= pointer.split("/")
     end
 
     def validate(data)

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -508,13 +508,18 @@ module JsonSchema
       else
         fragment = schema.fragment
         key = if fragment =~ /patternProperties/
-                idx = schema.split_pointer.index('patternProperties')
+                split_pointer = schema.pointer.split("/").reverse
+                idx = split_pointer.index('patternProperties')
+
                 # this join mimics the fragment format below in that it's
                 # parent + key
-                schema.split_pointer[idx - 2] + "/" + schema.split_pointer[idx - 1]
-              else
-                fragment
+                parts = split_pointer[(idx + 1)..(idx + 2)]
+
+                # protect against a `nil` that could occur if
+                # `patternProperties` has no parent
+                parts ? parts.compact.reverse.join("/") : nil
               end
+        key = fragment if key.nil?
         message = %{For '#{key}', #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
         errors << ValidationError.new(schema, path, message, :invalid_type)
         false

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -506,11 +506,14 @@ module JsonSchema
       if valid_types.any? { |t| data.is_a?(t) }
         true
       else
-        key = if schema.fragment =~ /patternProperties/
-                idx = schema.split_pointer.index("patternProperties")
-                schema.split_pointer[idx - 1]
+        fragment = schema.fragment
+        key = if fragment =~ /patternProperties/
+                idx = schema.split_pointer.index('patternProperties')
+                # this join mimics the fragment format below in that it's
+                # parent + key
+                schema.split_pointer[idx - 2] + "/" + schema.split_pointer[idx - 1]
               else
-                schema.split_pointer.last
+                fragment
               end
         message = %{For '#{key}', #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
         errors << ValidationError.new(schema, path, message, :invalid_type)

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -506,7 +506,7 @@ module JsonSchema
       if valid_types.any? { |t| data.is_a?(t) }
         true
       else
-        message = %{#{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
+        message = %{For #{schema.final_pointer}, #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
         errors << ValidationError.new(schema, path, message, :invalid_type)
         false
       end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -506,7 +506,13 @@ module JsonSchema
       if valid_types.any? { |t| data.is_a?(t) }
         true
       else
-        message = %{For #{schema.final_pointer}, #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
+        key = if schema.fragment =~ /patternProperties/
+                idx = schema.split_pointer.index("patternProperties")
+                schema.split_pointer[idx - 1]
+              else
+                schema.split_pointer.last
+              end
+        message = %{For '#{key}', #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
         errors << ValidationError.new(schema, path, message, :invalid_type)
         false
       end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -508,16 +508,18 @@ module JsonSchema
       else
         fragment = schema.fragment
         key = if fragment =~ /patternProperties/
-                split_pointer = schema.pointer.split("/").reverse
-                idx = split_pointer.index('patternProperties')
+                split_pointer = schema.pointer.split("/")
+                idx = split_pointer.index("patternProperties")
 
                 # this join mimics the fragment format below in that it's
                 # parent + key
-                parts = split_pointer[(idx + 1)..(idx + 2)]
+                if idx - 2 >= 0
+                  parts = split_pointer[(idx - 2)..(idx - 1)]
+                end
 
                 # protect against a `nil` that could occur if
                 # `patternProperties` has no parent
-                parts ? parts.compact.reverse.join("/") : nil
+                parts ? parts.compact.join("/") : nil
               end
         key = fragment if key.nil?
         message = %{For '#{key}', #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -450,6 +450,27 @@ describe JsonSchema::Validator do
     assert_includes error_types, :invalid_type
   end
 
+  it "validates patternProperties with missing parent" do
+    pointer("#").merge!(
+      "patternProperties" => {
+        "^S_" => {
+          "type" => "string"
+        }
+      }
+    )
+    pointer("#/definitions/app").merge!(
+      "additionalProperties" => true,
+      "required" => ["S_0"]
+    )
+
+    data_sample["S_0"] = 123
+    data_sample.delete("name")
+
+    refute validate
+    assert_includes error_messages, %{For '^S_', 123 is not a string.}
+    assert_includes error_types, :invalid_type
+  end
+
   it "validates required" do
     pointer("#/definitions/app/dependencies").merge!(
       "required" => ["name"]

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -40,7 +40,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{4 is not an object.}
+    assert_includes error_messages, %{For 'app', 4 is not an object.}
     assert_includes error_types, :invalid_type
   end
 
@@ -50,7 +50,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{4 is not a string.}
+    assert_includes error_messages, %{For 'app', 4 is not a string.}
     assert_includes error_types, :invalid_type
 
     pointer("#/definitions/app").merge!(
@@ -58,7 +58,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{4 is not a string or null.}
+    assert_includes error_messages, %{For 'app', 4 is not a string or null.}
     assert_includes error_types, :invalid_type
 
     pointer("#/definitions/app").merge!(
@@ -66,7 +66,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{4 is not an object, null, or string.}
+    assert_includes error_messages, %{For 'app', 4 is not an object, null, or string.}
     assert_includes error_types, :invalid_type
   end
 
@@ -382,7 +382,7 @@ describe JsonSchema::Validator do
     data_sample["foo"] = 4
     data_sample["matches_pattern"] = "yes!"
     refute validate
-    assert_includes error_messages, %{4 is not a boolean.}
+    assert_includes error_messages, %{For 'additionalProperties', 4 is not a boolean.}
     assert_includes error_types, :invalid_type
   end
 
@@ -446,7 +446,7 @@ describe JsonSchema::Validator do
       "KEY" => 456
     }
     refute validate
-    assert_includes error_messages, %{456 is not a null or string.}
+    assert_includes error_messages, %{For 'config_vars', 456 is not a null or string.}
     assert_includes error_types, :invalid_type
   end
 

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -40,7 +40,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{For 'app', 4 is not an object.}
+    assert_includes error_messages, %{For 'definitions/app', 4 is not an object.}
     assert_includes error_types, :invalid_type
   end
 
@@ -50,7 +50,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{For 'app', 4 is not a string.}
+    assert_includes error_messages, %{For 'definitions/app', 4 is not a string.}
     assert_includes error_types, :invalid_type
 
     pointer("#/definitions/app").merge!(
@@ -58,7 +58,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{For 'app', 4 is not a string or null.}
+    assert_includes error_messages, %{For 'definitions/app', 4 is not a string or null.}
     assert_includes error_types, :invalid_type
 
     pointer("#/definitions/app").merge!(
@@ -66,7 +66,7 @@ describe JsonSchema::Validator do
     )
     @data_sample = 4
     refute validate
-    assert_includes error_messages, %{For 'app', 4 is not an object, null, or string.}
+    assert_includes error_messages, %{For 'definitions/app', 4 is not an object, null, or string.}
     assert_includes error_types, :invalid_type
   end
 
@@ -446,7 +446,7 @@ describe JsonSchema::Validator do
       "KEY" => 456
     }
     refute validate
-    assert_includes error_messages, %{For 'config_vars', 456 is not a null or string.}
+    assert_includes error_messages, %{For 'definitions/config_vars', 456 is not a null or string.}
     assert_includes error_types, :invalid_type
   end
 


### PR DESCRIPTION
This PR updates the error messaging to note which property a schema fails for. 

We had an interesting case where a user tried to submit some data, and received the stark error message of `\nnil is not a string.\nnil is not a string.`. The problem was that the schema was violated in two places, but for the user, `nil is not a string` didn't really help them identify either one. It looked like a duplicated error in the message output.

This PR simply appends the final part of the schema pointer alongside the rest of the message. In the event that the schema is validating with a pattern, we need to travel up a bit to get the actual key name.

Thoughts?