### PR TITLE
Some slight changes to .travis.yml for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ script: bundle exec rake
 
 notifications:
   email: false
+
+sudo: false
+
+git:
+  depth: 10


### PR DESCRIPTION
* [`sudo: false`](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) moves the builds to the container infrastructure, which means faster builds.
* We can just limit the git clone depth to an arbitrary number (10) to make the clone a bit faster.