### PR TITLE
Create a mechanism for normalized release with Bundler's tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ Or run specific suites or tests with:
 ruby -Ilib -Itest test/json_schema/validator_test.rb
 ruby -Ilib -Itest test/json_schema/validator_test.rb -n /anyOf/
 ```
+
+## Release
+
+Use the `release` task:
+
+```
+bundle exec rake release
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
+require 'bundler'
 require "rake/testtask"
 
 task :default => :test
+
+Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new do |task|
   task.libs << "lib"


### PR DESCRIPTION
I always forget to push commits and/or tags and/or gems during a release, so let's normalize the process using Bundler's built-in helpers for it.

One caveat is that the format of the tag changes from "1.10.0" to one with a prefixed "v" like "v1.10.0", but that shouldn't matter all that much in the long run.

Almost a perfect copy of a sister pull in interagent/committee#89.