### PR TITLE
Support for TLDs with more than 4 characters

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -523,7 +523,7 @@ module JsonSchema
       end
     end
 
-    EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i
+    EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]+$/i
 
     HOSTNAME_PATTERN = /^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/
 

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -602,6 +602,14 @@ describe JsonSchema::Validator do
     assert validate
   end
 
+  it "validates email format with long TLDs successfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "email"
+    )
+    data_sample["owner"] = "dwarf@example.technology"
+    assert validate
+  end
+
   it "validates email format unsuccessfully" do
     pointer("#/definitions/app/definitions/owner").merge!(
       "format" => "email"


### PR DESCRIPTION
Bumped into a validation issue with email addresses on the new fancy TLDs such as .technology.

The list of currently valid TLDs can be seen at https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#ICANN-era_generic_top-level_domains