### PR TITLE
Expose data on ValidationError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 tags
 *.gem
+.bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 cache: bundler
 
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2
+
 script: bundle exec rake
 
 notifications:

--- a/lib/json_schema/schema_error.rb
+++ b/lib/json_schema/schema_error.rb
@@ -18,12 +18,13 @@ module JsonSchema
   end
 
   class ValidationError < SchemaError
-    attr_accessor :path, :sub_errors
+    attr_accessor :data, :path, :sub_errors
 
-    def initialize(schema, path, message, type, sub_errors = nil)
+    def initialize(schema, path, message, type, sub_errors = nil, data: nil)
       super(schema, message, type)
       @path = path
       @sub_errors = sub_errors
+      @data = data
     end
 
     def pointer

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -144,7 +144,7 @@ module JsonSchema
         validate_data(subschema, data, errors, path)
       end
       message = %{Not all subschemas of "allOf" matched.}
-      errors << ValidationError.new(schema, path, message, :all_of_failed) if !valid
+      errors << ValidationError.new(schema, path, message, :all_of_failed, data: data) if !valid
       valid
     end
 
@@ -161,7 +161,7 @@ module JsonSchema
 
       unless subschemata_validity.any? { |valid| valid == true }
         message = %{No subschema in "anyOf" matched.}
-        errors << ValidationError.new(schema, path, message, :any_of_failed, sub_errors)
+        errors << ValidationError.new(schema, path, message, :any_of_failed, sub_errors, data: data)
         return false
       end
 
@@ -208,7 +208,7 @@ module JsonSchema
         true
       else
         message = %{#{data} is not a valid #{schema.format}.}
-        errors << ValidationError.new(schema, path, message, :invalid_format)
+        errors << ValidationError.new(schema, path, message, :invalid_format, data: data)
         false
       end
     end
@@ -219,7 +219,7 @@ module JsonSchema
         true
       else
         message = %{#{data} is not a member of #{schema.enum}.}
-        errors << ValidationError.new(schema, path, message, :invalid_type)
+        errors << ValidationError.new(schema, path, message, :invalid_type, data: data)
         false
       end
     end
@@ -248,7 +248,7 @@ module JsonSchema
             %{ required; only #{data.size} } +
             (data.size == 1 ? "was" : "were") +
             %{ supplied.}
-          errors << ValidationError.new(schema, path, message, :min_items_failed)
+          errors << ValidationError.new(schema, path, message, :min_items_failed, data: data)
           false
         elsif data.size > schema.items.count && !schema.additional_items?
           message = %{No more than #{schema.items.count} item} +
@@ -256,7 +256,7 @@ module JsonSchema
             %{ allowed; #{data.size} } +
             (data.size > 1 ? "were" : "was") +
             %{ supplied.}
-          errors << ValidationError.new(schema, path, message, :max_items_failed)
+          errors << ValidationError.new(schema, path, message, :max_items_failed, data: data)
           false
         else
           valid = true
@@ -286,7 +286,7 @@ module JsonSchema
         message = %{#{data} must be less than} +
           (schema.max_exclusive? ? "" : " or equal to") +
           %{ #{schema.max}.}
-        errors << ValidationError.new(schema, path, message, :max_failed)
+        errors << ValidationError.new(schema, path, message, :max_failed, data: data)
         false
       end
     end
@@ -301,7 +301,7 @@ module JsonSchema
           %{ allowed; #{data.size} } +
           (data.size == 1 ? "was" : "were")+
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :max_items_failed)
+        errors << ValidationError.new(schema, path, message, :max_items_failed, data: data)
         false
       end
     end
@@ -316,7 +316,7 @@ module JsonSchema
           %{ allowed; #{data.length} } +
           (data.length == 1 ? "was" : "were") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :max_length_failed)
+        errors << ValidationError.new(schema, path, message, :max_length_failed, data: data)
         false
       end
     end
@@ -331,7 +331,7 @@ module JsonSchema
           %{ allowed; #{data.keys.size} } +
           (data.keys.size == 1 ? "was" : "were") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :max_properties_failed)
+        errors << ValidationError.new(schema, path, message, :max_properties_failed, data: data)
         false
       end
     end
@@ -346,7 +346,7 @@ module JsonSchema
         message = %{#{data} must be greater than} +
           (schema.min_exclusive? ? "" : " or equal to") +
           %{ #{schema.min}.}
-        errors << ValidationError.new(schema, path, message, :min_failed)
+        errors << ValidationError.new(schema, path, message, :min_failed, data: data)
         false
       end
     end
@@ -361,7 +361,7 @@ module JsonSchema
           %{ required; only #{data.size} } +
           (data.size == 1 ? "was" : "were") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :min_items_failed)
+        errors << ValidationError.new(schema, path, message, :min_items_failed, data: data)
         false
       end
     end
@@ -376,7 +376,7 @@ module JsonSchema
           %{ required; only #{data.length} } +
           (data.length == 1 ? "was" : "were") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :min_length_failed)
+        errors << ValidationError.new(schema, path, message, :min_length_failed, data: data)
         false
       end
     end
@@ -391,7 +391,7 @@ module JsonSchema
           %{ required; #{data.keys.size} }+
           (data.keys.size == 1 ? "was" : "were") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :min_properties_failed)
+        errors << ValidationError.new(schema, path, message, :min_properties_failed, data: data)
         false
       end
     end
@@ -402,7 +402,7 @@ module JsonSchema
         true
       else
         message = %{#{data} is not a multiple of #{schema.multiple_of}.}
-        errors << ValidationError.new(schema, path, message, :multiple_of_failed)
+        errors << ValidationError.new(schema, path, message, :multiple_of_failed, data: data)
         false
       end
     end
@@ -425,7 +425,7 @@ module JsonSchema
         else
           %{More than one subschema in "oneOf" matched.}
         end
-      errors << ValidationError.new(schema, path, message, :one_of_failed, sub_errors)
+      errors << ValidationError.new(schema, path, message, :one_of_failed, sub_errors, data: data)
 
       false
     end
@@ -437,7 +437,7 @@ module JsonSchema
       valid = !validate_data(schema.not, data, [], path)
       if !valid
         message = %{Matched "not" subschema.}
-        errors << ValidationError.new(schema, path, message, :not_failed)
+        errors << ValidationError.new(schema, path, message, :not_failed, data: data)
       end
       valid
     end
@@ -449,7 +449,7 @@ module JsonSchema
         true
       else
         message = %{#{data} does not match #{schema.pattern.inspect}.}
-        errors << ValidationError.new(schema, path, message, :pattern_failed)
+        errors << ValidationError.new(schema, path, message, :pattern_failed, data: data)
         false
       end
     end
@@ -508,7 +508,7 @@ module JsonSchema
       else
         key = find_parent(schema)
         message = %{For '#{key}', #{data.inspect} is not #{ErrorFormatter.to_list(schema.type)}.}
-        errors << ValidationError.new(schema, path, message, :invalid_type)
+        errors << ValidationError.new(schema, path, message, :invalid_type, data: data)
         false
       end
     end
@@ -519,7 +519,7 @@ module JsonSchema
         true
       else
         message = %{Duplicate items are not allowed.}
-        errors << ValidationError.new(schema, path, message, :unique_items_failed)
+        errors << ValidationError.new(schema, path, message, :unique_items_failed, data: data)
         false
       end
     end
@@ -542,7 +542,7 @@ module JsonSchema
             end
       key || fragment
     end
-    
+
     EMAIL_PATTERN = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]+$/i
 
     HOSTNAME_PATTERN = /^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -738,9 +738,9 @@ describe JsonSchema::Validator do
     pointer("#/definitions/app/definitions/owner").merge!(
       "format" => "uri"
     )
-    data_sample["owner"] = "http://"
+    data_sample["owner"] = "http://example.com[]"
     refute validate
-    assert_includes error_messages, %{http:// is not a valid uri.}
+    assert_includes error_messages, %{http://example.com[] is not a valid uri.}
     assert_includes error_types, :invalid_format
   end
 

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -42,6 +42,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{For 'definitions/app', 4 is not an object.}
     assert_includes error_types, :invalid_type
+    assert_includes error_data, 4
   end
 
   it "provides accurate error messages for multiple type errors" do
@@ -91,6 +92,7 @@ describe JsonSchema::Validator do
     assert_includes error_messages,
       %{1337 does not match /^[a-z][a-z\\-]*[a-z]$/.}
     assert_includes error_types, :pattern_failed
+    assert_includes error_data, "1337"
   end
 
   it "validates items with tuple successfully" do
@@ -128,6 +130,7 @@ describe JsonSchema::Validator do
     assert_includes error_messages,
       %{2 items required; only 1 was supplied.}
     assert_includes error_types, :min_items_failed
+    assert_includes error_data, ["cedar"]
   end
 
   it "validates items with tuple unsuccessfully for too many items" do
@@ -143,6 +146,7 @@ describe JsonSchema::Validator do
     assert_includes error_messages,
       %{No more than 2 items are allowed; 3 were supplied.}
       assert_includes error_types, :max_items_failed
+      assert_includes error_data, ["cedar", "https", "websockets"]
   end
 
   it "validates items with tuple unsuccessfully for non-conforming items" do
@@ -158,6 +162,7 @@ describe JsonSchema::Validator do
     assert_includes error_messages,
       %{1337 is not a member of ["http", "https"].}
     assert_includes error_types, :invalid_type
+    assert_includes error_data, "1337"
   end
 
   it "validates maxItems successfully" do
@@ -177,6 +182,7 @@ describe JsonSchema::Validator do
     assert_includes error_messages,
       %{No more than 10 items are allowed; 11 were supplied.}
     assert_includes error_types, :max_items_failed
+    assert_includes error_data, (0...11).to_a
   end
 
   it "validates minItems successfully" do
@@ -195,6 +201,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{1 item required; only 0 were supplied.}
     assert_includes error_types, :min_items_failed
+    assert_includes error_data, []
   end
 
   it "validates uniqueItems successfully" do
@@ -213,6 +220,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{Duplicate items are not allowed.}
     assert_includes error_types, :unique_items_failed
+    assert_includes error_data, ["websockets", "websockets"]
   end
 
   it "validates maximum for an integer with exclusiveMaximum false" do
@@ -224,6 +232,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{11 must be less than or equal to 10.}
     assert_includes error_types, :max_failed
+    assert_includes error_data, 11
   end
 
   it "validates maximum for an integer with exclusiveMaximum true" do
@@ -268,6 +277,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{0 must be greater than or equal to 1.}
     assert_includes error_types, :min_failed
+    assert_includes error_data, 0
   end
 
   it "validates minimum for an integer with exclusiveMaximum true" do
@@ -311,6 +321,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{1 is not a multiple of 2.}
     assert_includes error_types, :multiple_of_failed
+    assert_includes error_data, 1
   end
 
   it "validates multipleOf for a number" do
@@ -421,6 +432,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{No more than 0 properties are allowed; 1 was supplied.}
     assert_includes error_types, :max_properties_failed
+    assert_includes error_data, { "name" => "cloudnasium" }
   end
 
   it "validates minProperties" do
@@ -431,6 +443,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{At least 10 properties are required; 1 was supplied.}
     assert_includes error_types, :min_properties_failed
+    assert_includes error_data, { "name" => "cloudnasium" }
   end
 
   it "validates patternProperties" do
@@ -502,6 +515,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{At least 3 characters are required; only 2 were supplied.}
     assert_includes error_types, :all_of_failed
+    assert_includes error_data, "ab"
   end
 
   it "validates anyOf" do
@@ -521,6 +535,7 @@ describe JsonSchema::Validator do
     assert_includes sub_error_messages, [%{At least 5 characters are required; only 2 were supplied.}]
     assert_includes sub_error_messages, [%{At least 3 characters are required; only 2 were supplied.}]
     assert_equal sub_error_types, [[:min_length_failed], [:min_length_failed]]
+    assert_includes error_data, "ab"
   end
 
   it "validates oneOf" do
@@ -540,6 +555,7 @@ describe JsonSchema::Validator do
     sub_error_types = one_of_error.sub_errors.map { |errors| errors.map(&:type) }
     assert_equal sub_error_messages, [[], [], [%{foo does not match /^(hell|no)$/.}]]
     assert_equal sub_error_types, [[], [], [:pattern_failed]]
+    assert_includes error_data, "foo"
   end
 
   it "validates not" do
@@ -550,6 +566,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{Matched "not" subschema.}
     assert_includes error_types, :not_failed
+    assert_includes error_data, ""
   end
 
   it "validates date format successfully" do
@@ -600,6 +617,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{2014-05-13T08:42:40 is not a valid date-time.}
     assert_includes error_types, :invalid_format
+    assert_includes error_data, "2014-05-13T08:42:40"
   end
 
   it "validates email format successfully" do
@@ -772,6 +790,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{ab does not match /^[a-z][a-z0-9-]{3,30}$/.}
     assert_includes error_types, :pattern_failed
+    assert_includes error_data, "ab"
   end
 
   it "builds appropriate JSON Pointers to bad data" do
@@ -800,6 +819,10 @@ describe JsonSchema::Validator do
 
   def error_messages
     @validator.errors.map(&:message)
+  end
+
+  def error_data
+    @validator.errors.map(&:data)
   end
 
   def error_types


### PR DESCRIPTION
We're exposing error messages from JSON schema publicly in our API, and don't want to expose the format in https://github.com/brandur/json_schema/pull/32. Instead, it would be great to have access to the `data` to which the error belongs, so we can construct our own error messages. This PR makes that so.