### PR TITLE
Add customizable format validators

### DIFF
--- a/lib/json_schema/configuration.rb
+++ b/lib/json_schema/configuration.rb
@@ -1,15 +1,26 @@
 module JsonSchema
   class Configuration
+    attr_reader :custom_formats
     attr_reader :validate_regex_with
 
     def validate_regex_with=(validator)
       @validate_regex_with = validator
     end
 
+    def register_format(name, validator_proc)
+      @custom_formats[name] = validator_proc
+    end
+
+    # Used for testing.
+    def reset!
+      @validate_regex_with = nil
+      @custom_formats = {}
+    end
+
     private
 
     def initialize
-      @validate_regex_with = nil
+      reset!
     end
 
   end

--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -1,10 +1,11 @@
 require_relative "../json_reference"
+require_relative "validator"
 
 module JsonSchema
   class Parser
     ALLOWED_TYPES = %w{any array boolean integer number null object string}
     BOOLEAN = [FalseClass, TrueClass]
-    FORMATS = %w{date date-time email hostname ipv4 ipv6 regex uri uuid}
+    FORMATS = JsonSchema::Validator::DEFAULT_FORMAT_VALIDATORS.keys
     FRIENDLY_TYPES = {
       Array      => "array",
       FalseClass => "boolean",
@@ -346,9 +347,10 @@ module JsonSchema
     end
 
     def validate_format(schema, format)
-      return if FORMATS.include?(format)
+      valid_formats = FORMATS + JsonSchema.configuration.custom_formats.keys
+      return if valid_formats.include?(format)
 
-      message = %{#{format.inspect} is not a valid format, must be one of #{FORMATS.join(', ')}.}
+      message = %{#{format.inspect} is not a valid format, must be one of #{valid_formats.join(', ')}.}
       @errors << SchemaError.new(schema, message, :unknown_format)
     end
   end


### PR DESCRIPTION
Usage:

    JsonSchema.configure do |c|
      c.register_format "the-answer", ->(s) { s.to_i == 42 }
    end
    # { "type": "string", "format": "the-answer" } now matches the string
    # "42xx" but not "43xx".

I'd prefer a way to configure this on a per-parser/per-validator level, but I
wasn't sure where the data about the set of format validators should go, given
that the information needs to be available to both the parser (to check that
the format is a valid one) and the validator (to know how to actually validate
the data).

Fixes #38.