### PR TITLE
Add 2.3 to list of tested Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.0-preview2
 
 script: bundle exec rake
 


### PR DESCRIPTION
Start testing `json_schema` under 2.3 (currently under preview, but
expected to be released fairly soon).