### PR TITLE
Raise typed errors

### DIFF
--- a/lib/json_pointer/evaluator.rb
+++ b/lib/json_pointer/evaluator.rb
@@ -16,7 +16,7 @@ module JsonPointer
       end
 
       if path[0] != "/"
-        raise %{Path must begin with a leading "/": #{original_path}.}
+        raise ArgumentError, %{Path must begin with a leading "/": #{original_path}.}
       end
 
       path_parts = split(path)
@@ -35,7 +35,7 @@ module JsonPointer
         key = transform_key(path_parts.shift)
         if data.is_a?(Array)
           unless key =~ /^\d+$/
-            raise %{Key operating on an array must be a digit or "-": #{key}.}
+            raise ArgumentError, %{Key operating on an array must be a digit or "-": #{key}.}
           end
           evaluate_segment(data[key.to_i], path_parts)
         else

--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -1,9 +1,9 @@
 require_relative "json_schema/configuration"
 require_relative "json_schema/document_store"
+require_relative "json_schema/error"
 require_relative "json_schema/parser"
 require_relative "json_schema/reference_expander"
 require_relative "json_schema/schema"
-require_relative "json_schema/schema_error"
 require_relative "json_schema/validator"
 
 module JsonSchema

--- a/lib/json_schema/document_store.rb
+++ b/lib/json_schema/document_store.rb
@@ -13,7 +13,7 @@ module JsonSchema
     end
 
     def add_schema(schema)
-      raise "can't add nil URI" if schema.uri.nil?
+      raise ArgumentError, "can't add nil URI" if schema.uri.nil?
       uri = schema.uri.chomp('#')
       @schema_map[uri] = schema
     end

--- a/lib/json_schema/error.rb
+++ b/lib/json_schema/error.rb
@@ -1,5 +1,20 @@
 module JsonSchema
-  class SchemaError
+  class Error < RuntimeError
+  end
+
+  class AggregateError < Error
+    attr_accessor :errors
+
+    def initialize(errors)
+      @errors = errors
+    end
+
+    def to_s
+      @errors.join(" ")
+    end
+  end
+
+  class SchemaError < Error
     attr_accessor :message, :schema, :type
 
     def self.aggregate(errors)

--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -37,7 +37,7 @@ module JsonSchema
     def parse!(data, parent = nil)
       schema = parse(data, parent)
       if !schema
-        raise @errors.join(" ")
+        raise AggregateError.new(@errors)
       end
       schema
     end

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -33,7 +33,7 @@ module JsonSchema
 
     def expand!(schema, options = {})
       if !expand(schema, options)
-        raise @errors.join(" ")
+        raise AggregateError.new(@errors)
       end
       true
     end

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -27,7 +27,7 @@ module JsonSchema
 
     def validate!(data)
       if !validate(data)
-        raise @errors.join(" ")
+        raise AggregateError.new(@errors)
       end
     end
 

--- a/test/json_pointer/evaluator_test.rb
+++ b/test/json_pointer/evaluator_test.rb
@@ -31,14 +31,14 @@ describe JsonPointer::Evaluator do
   end
 
   it "raises when a path doesn't being with /" do
-    e = assert_raises(RuntimeError) { @evaluator.evaluate("foo") }
+    e = assert_raises(ArgumentError) { @evaluator.evaluate("foo") }
     assert_equal %{Path must begin with a leading "/": foo.}, e.message
-    e = assert_raises(RuntimeError) { @evaluator.evaluate("#foo") }
+    e = assert_raises(ArgumentError) { @evaluator.evaluate("#foo") }
     assert_equal %{Path must begin with a leading "/": #foo.}, e.message
   end
 
   it "raises when a non-digit is specified on an array" do
-    e = assert_raises(RuntimeError) { @evaluator.evaluate("/foo/bar") }
+    e = assert_raises(ArgumentError) { @evaluator.evaluate("/foo/bar") }
     assert_equal %{Key operating on an array must be a digit or "-": bar.},
       e.message
   end

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -307,6 +307,18 @@ describe JsonSchema::Parser do
     assert_includes error_types, :unknown_format
   end
 
+  it "raises an aggregate error with parse!" do
+    schema_sample["id"] = 4
+
+    parser = JsonSchema::Parser.new
+
+    # don't bother checking the particulars of the error here because we have
+    # other tests for that above
+    assert_raises JsonSchema::AggregateError do
+      parser.parse!(schema_sample)
+    end
+  end
+
   def error_messages
     @parser.errors.map { |e| e.message }
   end

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -212,6 +212,21 @@ describe JsonSchema::ReferenceExpander do
     assert_includes error_types, :unresolved_references
   end
 
+  it "raises an aggregate error with expand!" do
+    pointer("#/properties").merge!(
+      "app" => { "$ref" => "#/definitions/nope" }
+    )
+
+    schema = JsonSchema::Parser.new.parse!(schema_sample)
+    expander = JsonSchema::ReferenceExpander.new
+
+    # don't bother checking the particulars of the error here because we have
+    # other tests for that above
+    assert_raises JsonSchema::AggregateError do
+      expander.expand!(schema)
+    end
+  end
+
   def error_messages
     @expander.errors.map { |e| e.message }
   end

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -841,6 +841,23 @@ describe JsonSchema::Validator do
     assert_includes error_types, :invalid_format
   end
 
+  it "raises an aggregate error with validate!" do
+    pointer("#/definitions/app").merge!(
+      "type" => ["object"]
+    )
+
+    schema = JsonSchema.parse!(schema_sample)
+    schema.expand_references!
+    schema = schema.definitions["app"]
+    validator = JsonSchema::Validator.new(schema)
+
+    # don't bother checking the particulars of the error here because we have
+    # other tests for that above
+    assert_raises JsonSchema::AggregateError do
+      validator.validate!(4)
+    end
+  end
+
   def data_sample
     @data_sample ||= DataScaffold.data_sample
   end


### PR DESCRIPTION
Changes all the places in the library where we raise generic errors to
typed errors. These fall into two categories:

* When appropriate, I've tried to raise `ArgumentError`.
* Otherwise, I've defined a `JsonSchema::Error` from which all other
  thrown errors are inherited. The bang methods (`expand!`, `parse!`,
  and `validate!`) throw a new `JsonSchema::AggregateError` instead of
  just a `RuntimeError` with some strings concatenated. The new error is
  still a descendant of `RuntimeError` so this isn't a breaking change.

Fixes #49.