### PR TITLE
Add a failing test case for type (string, null) + enum

### DIFF
--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -38,6 +38,15 @@ describe JsonSchema::Validator do
     assert validate
   end
 
+  it "validates type with enum successfully" do
+    pointer("#/definitions/app/definitions/visibility").merge!(
+      "type" => ["string", "null"],
+      "enum" => ["private", "public"]
+    )
+    data_sample["visibility"] = nil
+    assert validate
+  end
+
   it "validates type unsuccessfully" do
     pointer("#/definitions/app").merge!(
       "type" => ["object"]


### PR DESCRIPTION
If I have understood correctly, JSON schema defines a `type` validator to pass if any of the types in the array pass. This gem however fails when the `type` is `["string", "null"]` and also the `enum` property is defined with no explicit `null` value.

Funnily enough, this case passes the test:

```ruby
it "validates type with enum successfully" do
  pointer("#/definitions/app/definitions/visibility").merge!(
    "type" => ["string", "null"],
    "enum" => ["private", "public", nil]
  )
  data_sample["visibility"] = nil
  assert validate
end
```

Seems like if the `enum` array also has an explicit `null` in there, it is the only way to get an optional enum value to pass.

I guess this issue might've been resolved by #13 already if that was done.