### PR TITLE
Do not update DocumentStore with subschema

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -42,6 +42,8 @@ module JsonSchema
 
     def add_reference(schema)
       uri = URI.parse(schema.uri)
+      return if (stored_schema = lookup_reference(uri)) && stored_schema.pointer != schema.pointer
+
       if uri.absolute?
         @store.add_schema(schema)
       else

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -42,7 +42,8 @@ module JsonSchema
 
     def add_reference(schema)
       uri = URI.parse(schema.uri)
-      return if (stored_schema = lookup_reference(uri)) && stored_schema.pointer != schema.pointer
+      # do not update with subschema (longer is subschema)
+      return if (stored_schema = lookup_reference(uri)) && (stored_schema.pointer.length < schema.pointer.length)
 
       if uri.absolute?
         @store.add_schema(schema)


### PR DESCRIPTION
First, sorry for not adding any additional tests and my poor implementations(just workaround).

When I fought with my really complex json schema, I found the expansion of it wired.
It returned incorrect reference.

That is because document store is updated by subschema:
https://github.com/brandur/json_schema/blob/acd1ad328a375e0761122b9f3e5fd5e0b2b013c8/lib/json_schema/reference_expander.rb#L264