### PR TITLE
Fix test

### DIFF
--- a/test/json_schema_test.rb
+++ b/test/json_schema_test.rb
@@ -28,7 +28,7 @@ describe JsonSchema do
       pointer("#/properties").merge!(
         "app" => 4
       )
-      e = assert_raises(RuntimeError) do
+      e = assert_raises(JsonSchema::AggregateError) do
         JsonSchema.parse!(schema_sample)
       end
       assert_includes e.message, %{4 is not a valid schema.}


### PR DESCRIPTION
Before: 
```
  1) Failure:
test_0002_returns errors on a parsing problem(JsonSchema::.parse!) [/Users/brian/src/json_schema/test/json_schema_test.rb:31]:
[RuntimeError] exception expected, not
Class: <JsonSchema::AggregateError>
Message: <"#: 4 is not a valid schema.">
---Backtrace---
/Users/brian/src/json_schema/lib/json_schema/parser.rb:40:in `parse!'
/Users/brian/src/json_schema/lib/json_schema.rb:28:in `parse!'
/Users/brian/src/json_schema/test/json_schema_test.rb:32:in `block (4 levels) in <top (required)>'
```