### PR TITLE
Run tests with warnings enabled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,6 @@ Rake::TestTask.new do |task|
   task.libs << "test"
   task.name = :test
   task.test_files = FileList["test/**/*_test.rb"]
+  task.ruby_opts = '' if task.ruby_opts.nil?
+  task.ruby_opts << ' -w' unless ENV['NO_WARN'] == 'true'
 end


### PR DESCRIPTION
Should help clean up warnings in gems or apps that use json_schema ;)

refs:
- http://mislav.net/2011/06/ruby-verbose-mode/