### PR TITLE
Fix bug when ref_schema doesn't have a URI.

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -184,7 +184,7 @@ module JsonSchema
       elsif uri && uri.path[0] == "/"
         resolve_uri(ref_schema, uri)
       # relative
-      elsif uri
+      elsif uri && ref_schema.uri
         # build an absolute path using the URI of the current schema
         # TODO: fix this. References don't get URIs which might be an error.
         schema_uri = ref_schema.uri.chomp("/")


### PR DESCRIPTION
I'm not quite sure this is the right thing to do. It seems better than the current behavior, which blindly trys to chomp schema_ref.uri.