### PR TITLE
Fix all warnings

### DIFF
--- a/lib/json_reference.rb
+++ b/lib/json_reference.rb
@@ -13,6 +13,9 @@ module JsonReference
     attr_accessor :uri
 
     def initialize(ref)
+      # Note that the #to_s of `nil` is an empty string.
+      @uri = nil
+
       # given a simple fragment without '#', resolve as a JSON Pointer only as
       # per spec
       if ref.include?("#")

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -185,6 +185,7 @@ module JsonSchema
         resolve_uri(ref_schema, uri)
       # relative
       elsif uri
+require "pry"
         # build an absolute path using the URI of the current schema
         # TODO: fix this. References don't get URIs which might be an error.
         schema_uri = ref_schema.uri.chomp("/")

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -12,6 +12,9 @@ module JsonSchema
     end
 
     def self.attr_reader_default(attr, default)
+      # remove the reader already created by attr_accessor
+      remove_method(attr)
+
       class_eval("def #{attr} ; !@#{attr}.nil? ? @#{attr} : #{default} ; end")
     end
 
@@ -283,11 +286,11 @@ module JsonSchema
 
       # schema attributes
       attr_accessor :description
-      attr_accessor :enc_type
+      attr_writer :enc_type
       attr_accessor :href
+      attr_writer :media_type
       attr_accessor :method
       attr_accessor :rel
-      attr_accessor :media_type
       attr_accessor :schema
       attr_accessor :target_schema
       attr_accessor :title

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -52,7 +52,7 @@ describe JsonSchema::Parser do
 
   it "parses array validations" do
     schema = parse.definitions["app"].definitions["flags"]
-    assert_equal /^[a-z][a-z\-]*[a-z]$/, schema.items.pattern
+    assert_equal(/^[a-z][a-z\-]*[a-z]$/, schema.items.pattern)
     assert_equal 1, schema.min_items
     assert_equal 10, schema.max_items
     assert_equal true, schema.unique_items
@@ -140,7 +140,7 @@ describe JsonSchema::Parser do
   it "parses the patternProperties object validation" do
     schema = parse.definitions["app"].definitions["config_vars"]
     property = schema.pattern_properties.first
-    assert_equal /^\w+$/, property[0]
+    assert_equal(/^\w+$/, property[0])
     assert_equal ["null", "string"], property[1].type
   end
 
@@ -171,7 +171,7 @@ describe JsonSchema::Parser do
     schema = parse.definitions["app"].definitions["name"]
     assert_equal 30, schema.max_length
     assert_equal 3, schema.min_length
-    assert_equal /^[a-z][a-z0-9-]{3,30}$/, schema.pattern
+    assert_equal(/^[a-z][a-z0-9-]{3,30}$/, schema.pattern)
   end
 
   it "parses hypermedia links" do
@@ -214,7 +214,6 @@ describe JsonSchema::Parser do
       "type"           => "image/png"
     )
     schema = parse.definitions["app"]
-    media = JsonSchema::Schema::Media.new
     assert_equal "base64", schema.media.binary_encoding
     assert_equal "image/png", schema.media.type
   end

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -79,15 +79,15 @@ describe JsonSchema::ReferenceExpander do
     expand
     assert_equal [], error_messages
     schema = @schema.properties["app"].definitions["contrived_plus"]
-    assert_equal /^(foo|aaa)$/, schema.one_of[0].pattern
-    assert_equal /^(foo|zzz)$/, schema.one_of[1].pattern
+    assert_equal(/^(foo|aaa)$/, schema.one_of[0].pattern)
+    assert_equal(/^(foo|zzz)$/, schema.one_of[1].pattern)
   end
 
   it "will expand not" do
     expand
     assert_equal [], error_messages
     schema = @schema.properties["app"].definitions["contrived_plus"]
-    assert_equal /^$/, schema.not.pattern
+    assert_equal(/^$/, schema.not.pattern)
   end
 
   it "will expand additionalProperties" do

--- a/test/json_schema_test.rb
+++ b/test/json_schema_test.rb
@@ -7,6 +7,7 @@ describe JsonSchema do
     it "succeeds" do
       schema, errors = JsonSchema.parse(schema_sample)
       assert schema
+      assert_equal nil, errors
     end
 
     it "returns errors on a parsing problem" do


### PR DESCRIPTION
Apparently newer versions of Ruby have found a lot of minor problems
with the project -- largely issues like a method being redefined because
an accessor adder was being called twice.

This patch fixes all those warnings and is very low risk.