### PR TITLE
Fix nil exception when trying to expand relative reference

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -186,9 +186,13 @@ module JsonSchema
       # relative
       elsif uri
         # build an absolute path using the URI of the current schema
-        # TODO: fix this. References don't get URIs which might be an error.
-        schema_uri = ref_schema.uri.chomp("/")
-        resolve_uri(ref_schema, URI.parse(schema_uri + "/" + uri.path))
+        if ref_schema.uri
+          schema_uri = ref_schema.uri.chomp("/")
+          resolve_uri(ref_schema, URI.parse(schema_uri + "/" + uri.path))
+        else
+          nil
+        end
+
       # just a JSON Pointer -- resolve against schema root
       else
         resolve_pointer(ref_schema, @schema)

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -185,7 +185,10 @@ module JsonSchema
         resolve_uri(ref_schema, uri)
       # relative
       elsif uri
-        # build an absolute path using the URI of the current schema
+        # Build an absolute path using the URI of the current schema.
+        #
+        # Note that this code path will never currently be hit because the
+        # incoming reference schema will never have a URI.
         if ref_schema.uri
           schema_uri = ref_schema.uri.chomp("/")
           resolve_uri(ref_schema, URI.parse(schema_uri + "/" + uri.path))

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -205,6 +205,16 @@ describe JsonSchema::ReferenceExpander do
     assert_includes error_types, :unresolved_pointer
   end
 
+  it "errors on a relative URI that cannot be transformed to an absolute" do
+    pointer("#/properties").merge!(
+      "app" => { "$ref" => "relative#definitions/name" }
+    )
+    refute expand
+    assert_includes error_messages,
+      %{Couldn't resolve references: relative#definitions/name.}
+    assert_includes error_types, :unresolved_references
+  end
+
   it "errors on a reference cycle" do
     pointer("#/properties").merge!(
       "app0" => { "$ref" => "#/properties/app2" },


### PR DESCRIPTION
When trying to expand relative references we can encounter a nil error when we try to examine the URI of the current schema and it doesn't have one. This patches the issue by just returning a `nil` in that situation so that a standard unresolvable reference error occurs.

Replaces #66.