### PR TITLE
Produce an error on empty files

### DIFF
--- a/lib/commands/validate_schema.rb
+++ b/lib/commands/validate_schema.rb
@@ -98,10 +98,19 @@ module Commands
 
     def read_file(file)
       contents = File.read(file)
-      if File.extname(file) == ".yaml"
-        YAML.load(contents)
+
+      # Perform an empty check because boath YAML and JSON's load will return
+      # `nil` in the case of an empty file, which will otherwise produce
+      # confusing results.
+      if contents.empty?
+        @errors = ["#{file}: File is empty."]
+        nil
       else
-        JSON.load(contents)
+        if File.extname(file) == ".yaml"
+          YAML.load(contents)
+        else
+          JSON.load(contents)
+        end
       end
     rescue Errno::ENOENT
       @errors = ["#{file}: No such file or directory."]

--- a/test/commands/validate_schema_test.rb
+++ b/test/commands/validate_schema_test.rb
@@ -71,6 +71,14 @@ describe Commands::ValidateSchema do
     refute success
   end
 
+  it "errors on empty files" do
+    temp_file("") do |path|
+      success = @command.run([hyper_schema_path, path])
+      assert_equal ["#{path}: File is empty."], @command.errors
+      refute success
+    end
+  end
+
   def basic_hyper_schema
     <<-eos
       { "$schema": "http://json-schema.org/draft-04/hyper-schema" }


### PR DESCRIPTION
Currently, when given an empty data file, the validation command
produces usage information, which is super confusing and doesn't tell
the user anything. This is a side effect of the fact that both
`JSON.load` and `YAML.load` will produce a `nil` when they're passed an
empty string, so the command finishes with an empty set of errors but
also unsuccessfully.

Here we add a new error message so that reasonable output is produced in
this error case.