### PR TITLE
Include URI that could not be resolved in error message

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -176,7 +176,7 @@ module JsonSchema
           resolve_uri(ref_schema, uri)
         else
           message =
-            %{Reference resolution over #{scheme} is not currently supported.}
+            %{Reference resolution over #{scheme} is not currently supported (URI: #{uri}).}
           @errors << SchemaError.new(ref_schema, message, :scheme_not_supported)
           nil
         end


### PR DESCRIPTION
This error message can be pretty confusing when you have big schemas
with a lot stuff. Put the failed URI into the error message so that it's
a little easier for a user to glean what's going on.