### PR TITLE
Expand a schema that is _just_ a reference

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -11,7 +11,14 @@ module JsonSchema
       @schema       = schema
       @schema_paths = {}
       @store        = options[:store] || DocumentStore.new
-      @uri          = URI.parse(schema.uri)
+
+      # If the given JSON schema is _just_ a JSON reference and nothing else,
+      # short circuit the whole expansion process and return the result.
+      if schema.reference && !schema.expanded?
+        return dereference(schema, [])
+      end
+
+      @uri = URI.parse(schema.uri)
 
       @store.each do |uri, store_schema|
         build_schema_paths(uri, store_schema)

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -244,6 +244,27 @@ describe JsonSchema::ReferenceExpander do
     end
   end
 
+  it "expands a schema that is just a reference" do
+    # First initialize another schema. Give it a fully qualified URI so that we
+    # can reference it across schemas.
+    schema = JsonSchema::Parser.new.parse!(schema_sample)
+    schema.uri = "http://json-schema.org/test"
+
+    # Initialize a store and add our schema to it.
+    store = JsonSchema::DocumentStore.new
+    store.add_schema(schema)
+
+    # Have the parser parse _just_ a reference. It should resolve to a
+    # subschema in the schema that we initialized above.
+    schema = JsonSchema::Parser.new.parse!(
+      { "$ref" => "http://json-schema.org/test#/definitions/app" }
+    )
+    expander = JsonSchema::ReferenceExpander.new
+    expander.expand!(schema, store: store)
+
+    assert schema.expanded?
+  end
+
   def error_messages
     @expander.errors.map { |e| e.message }
   end


### PR DESCRIPTION
The current reference expander does a pretty good job of expanding
references that exist as subschemas in the schema, but fails to expand a
schema that is _just_ a JSON reference and nothing else.

This adds some code to short circuit the expansion mechanism if we
detect a simple JSON reference and nothing else.