### PR TITLE
Enable SchemaError to #to_s even if schema pointer not present

### DIFF
--- a/lib/json_schema/error.rb
+++ b/lib/json_schema/error.rb
@@ -28,7 +28,11 @@ module JsonSchema
     end
 
     def to_s
-      "#{schema.pointer}: #{message}"
+      if schema && schema.pointer
+        "#{schema.pointer}: #{message}"
+      else
+        message
+      end
     end
   end
 

--- a/test/json_schema/error_test.rb
+++ b/test/json_schema/error_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+require "json_schema"
+
+describe JsonSchema::SchemaError do
+  it "can print a message with a pointer" do
+    schema = JsonSchema::Schema.new
+    schema.fragment = "#"
+
+    e = JsonSchema::SchemaError.new(schema, "problem", nil)
+    assert_equal "#: problem", e.to_s
+  end
+
+  it "can print a message without a pointer" do
+    e = JsonSchema::SchemaError.new(nil, "problem", nil)
+    assert_equal "problem", e.to_s
+  end
+end


### PR DESCRIPTION
It seems that I run into quite a few errors while debugging that
actually occur because Ruby is trying to show me a SchemaError but can't
because its #to_s can't run because no pointer is present.

This patch still shows the same information in #to_s, but makes the
method a little more robust in that it can still run even if a schema
wasn't present. This probably still represents a problem case, but if we
want to throw an error, doing so from inside an error class isn't the
place to do it.