### PR TITLE
When expanding references, evaluate JSON pointers in current schema

### DIFF
--- a/lib/json_pointer/evaluator.rb
+++ b/lib/json_pointer/evaluator.rb
@@ -1,4 +1,9 @@
 module JsonPointer
+  # Evaluates a JSON pointer within a JSON document.
+  #
+  # Note that this class is designed to evaluate references across a plain JSON
+  # data object _or_ an instance of `JsonSchema::Schema`, so the constructor's
+  # `data` argument can be of either type.
   class Evaluator
     def initialize(data)
       @data = data

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -139,10 +139,10 @@ module JsonSchema
       ref = ref_schema.reference
 
       if !(new_schema = lookup_pointer(ref.uri, ref.pointer))
-        data = JsonPointer.evaluate(resolved_schema.data, ref.pointer)
+        new_schema = JsonPointer.evaluate(resolved_schema, ref.pointer)
 
         # couldn't resolve pointer within known schema; that's an error
-        if data.nil?
+        if new_schema.nil?
           message = %{Couldn't resolve pointer "#{ref.pointer}".}
           @errors << SchemaError.new(resolved_schema, message, :unresolved_pointer)
           return
@@ -153,14 +153,13 @@ module JsonSchema
         #
         #     https://github.com/brandur/json_schema/issues/50
         #
-        if new_schema = lookup_pointer(ref.uri, data["$ref"])
-          new_schema.clones << ref_schema
+        if new_schema.reference &&
+          new_new_schema = lookup_pointer(ref.uri, new_schema.reference.pointer)
+            new_new_schema.clones << ref_schema
         else
           # Parse a new schema and use the same parent node. Basically this is
           # exclusively for the case of a reference that needs to be
           # de-referenced again to be resolved.
-          # TODO: Fix to never parse.
-          new_schema = Parser.new.parse(data, ref_schema.parent)
           build_schema_paths(ref.uri, resolved_schema)
         end
       else

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -210,6 +210,14 @@ module JsonSchema
     alias :read_only? :read_only
     alias :unique_items? :unique_items
 
+    # Allows the values of schema attributes to be accessed with a symbol or a
+    # string. So for example, the value of `schema.additional_items` could be
+    # procured with `schema[:additionalItems]`. This only works for attributes
+    # that are part of the JSON schema specification; other methods on the
+    # class are not available (e.g. `expanded`.)
+    #
+    # This is implemented so that `JsonPointer::Evaluator` can evaluate a
+    # reference on an sintance of this class (as well as plain JSON data).
     def [](name)
       name = name.to_sym
       if @@schema_attrs.key?(name)

--- a/test/json_pointer/evaluator_test.rb
+++ b/test/json_pointer/evaluator_test.rb
@@ -43,6 +43,14 @@ describe JsonPointer::Evaluator do
       e.message
   end
 
+  it "can evaluate on a schema object" do
+    schema = JsonSchema.parse!(DataScaffold.schema_sample)
+    evaluator = JsonPointer::Evaluator.new(schema)
+    res = evaluator.evaluate("#/definitions/app/definitions/contrived/allOf/0")
+    assert_kind_of JsonSchema::Schema, res
+    assert 30, res.max_length
+  end
+
   def data
    {
       "foo"  => ["bar", "baz"],

--- a/test/json_schema/schema_test.rb
+++ b/test/json_schema/schema_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+require "json_schema"
+
+describe JsonSchema::Schema do
+  it "allows schema attribute access with #[]" do
+    schema = JsonSchema::Schema.new
+    schema.properties = { "foo" => nil }
+    assert_equal({ "foo" => nil }, schema[:properties])
+  end
+
+  it "allows schema attribute access with #[] and overridden name" do
+    schema = JsonSchema::Schema.new
+    schema.additional_properties = { "foo" => nil }
+    assert_equal({ "foo" => nil }, schema[:additionalProperties])
+  end
+
+  it "allows schema attribute access with #[] as string" do
+    schema = JsonSchema::Schema.new
+    schema.properties = { "foo" => nil }
+    assert_equal({ "foo" => nil }, schema["properties"])
+  end
+
+  it "raises if attempting to access #[] with bad method" do
+    schema = JsonSchema::Schema.new
+    assert_raises NoMethodError do
+      schema[:wat]
+    end
+  end
+
+  it "raises if attempting to access #[] with non-schema attribute" do
+    schema = JsonSchema::Schema.new
+    assert_raises NoMethodError do
+      schema[:expanded]
+    end
+  end
+end


### PR DESCRIPTION
Up until now, if a JSON reference happened to point over to another schema, we'd resolve that pointer according to the schema's raw data and not the parsed schema itself. After resolving the pointer, we'd parse whatever JSON data that it had pointed to.

This mostly worked, but wasn't very efficient, and in a case where we pointed to data that _was a JSON reference itself_, that reference would come back parsed but not expanded.

This patch augments the JSON pointer evaluator so that it can resolve across either raw JSON data _or_ an instance of `JsonSchema::Schema`. We then use this to our advantage in the JSON reference expander by just re-using the schema that we're already expanding.