### PR TITLE
Basic testing on executables

### DIFF
--- a/bin/validate-schema
+++ b/bin/validate-schema
@@ -10,7 +10,7 @@ end
 
 command = Commands::ValidateSchema.new
 
-OptionParser.new { |opts|
+parser = OptionParser.new { |opts|
   opts.on("-d", "--detect", "Detect schema from $schema") do
     command.detect = true
 
@@ -21,16 +21,19 @@ OptionParser.new { |opts|
   opts.on("-s", "--schema SCHEMA", "Additional schema to use for references") do |s|
     command.extra_schemas << s
   end
-}.parse!
+}
 
-success = command.run(ARGV.dup)
+if $0 == __FILE__
+  parser.parse!
+  success = command.run(ARGV.dup)
 
-if success
-  command.messages.each { |m| $stdout.puts(m) }
-elsif !command.errors.empty?
-  command.errors.each { |e| $stderr.puts(e) }
-  exit(1)
-else
-  print_usage!
-  exit(1)
+  if success
+    command.messages.each { |m| $stdout.puts(m) }
+  elsif !command.errors.empty?
+    command.errors.each { |e| $stderr.puts(e) }
+    exit(1)
+  else
+    print_usage!
+    exit(1)
+  end
 end

--- a/test/bin_test.rb
+++ b/test/bin_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+#
+# The purpose of this sets of tests is just to include our Ruby executables
+# where possible so that we can get very basic sanity checks on their syntax
+# (which is something that of course Ruby can't do by default).
+#
+# We can do this without actually executing them because they're gated by `if
+# $0 == __FILE__` statements.
+#
+
+describe "executables in bin/" do
+  before do
+    @bin_dir = File.expand_path("../../bin", __FILE__)
+  end
+
+  it "has roughly valid Ruby structure for validate-schema" do
+    load File.join(@bin_dir, "validate-schema")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,12 @@
 if RUBY_VERSION >= '2.0.0'
   require 'simplecov'
   SimpleCov.start do
+    # We do our utmost to test our executables by modularizing them into
+    # testable pieces, but testing them to completion is nearly impossible as
+    # far as I can tell, so include them in our tests but don't calculate
+    # coverage.
+    add_filter "/bin/"
+
     add_filter "/test/"
   end
 end


### PR DESCRIPTION
Loads executables in the test suite so that we at least get a basic
check that their syntax is correct.

Exclude executables from code coverage measurements because it's nigh
impossible to get all lines.