### PR TITLE
Fix reference expansion for hyper-schema links

### DIFF
--- a/lib/json_schema.rb
+++ b/lib/json_schema.rb
@@ -1,3 +1,4 @@
+require_relative "json_schema/attributes"
 require_relative "json_schema/configuration"
 require_relative "json_schema/document_store"
 require_relative "json_schema/error"

--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -37,20 +37,16 @@ module JsonSchema
       # Directive indicating that attributes should be inherited from a parent
       # class.
       #
-      # Must appear as first statement in class that mixes in the Attributes
-      # module. Either this method *or* #initialize_attrs should be used, but
-      # not both.
+      # Must appear as first statement in class that mixes in (or whose parent
+      # mixes in) the Attributes module.
       def inherit_attrs
         @copyable_attrs = self.superclass.instance_variable_get(:@copyable_attrs)
         @schema_attrs = self.superclass.instance_variable_get(:@schema_attrs)
       end
 
       # Initializes some class instance variables required to make other
-      # methods in the Attributes module work.
-      #
-      # Must appear as first statement in class that mixes in the Attributes
-      # module. Either this method *or* #initialize_attrs should be used, but
-      # not both.
+      # methods in the Attributes module work. Run automatically when the
+      # module is mixed into another class.
       def initialize_attrs
         @copyable_attrs = []
         @schema_attrs = {}
@@ -59,6 +55,7 @@ module JsonSchema
 
     def self.included(klass)
       klass.extend(ClassMethods)
+      klass.send(:initialize_attrs)
     end
 
     # Allows the values of schema attributes to be accessed with a symbol or a

--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -1,0 +1,93 @@
+module JsonSchema
+  # Attributes mixes in some useful attribute-related methods for use in
+  # defining schema classes in a spirit similar to Ruby's attr_accessor and
+  # friends.
+  module Attributes
+    # Provides class-level methods for the Attributes module.
+    module ClassMethods
+      attr_reader :copyable_attrs
+
+      # Attributes that are part of the JSON schema and hyper-schema
+      # specifications. These are allowed to be accessed with the [] operator.
+      #
+      # Hash contains the access key mapped to the name of the method that should
+      # be invoked to retrieve a value. For example, `type` maps to `type` and
+      # `additionalItems` maps to `additional_items`.
+      attr_reader :schema_attrs
+
+      # identical to attr_accessible, but allows us to copy in values from a
+      # target schema to help preserve our hierarchy during reference expansion
+      def attr_copyable(attr)
+        attr_accessor(attr)
+        self.copyable_attrs << "@#{attr}".to_sym
+      end
+
+      def attr_schema(attr, options = {})
+        attr_copyable(attr)
+        self.schema_attrs[options[:schema_name] || attr] = attr
+      end
+
+      def attr_reader_default(attr, default)
+        # remove the reader already created by attr_accessor
+        remove_method(attr)
+
+        class_eval("def #{attr} ; !@#{attr}.nil? ? @#{attr} : #{default} ; end")
+      end
+
+      # Directive indicating that attributes should be inherited from a parent
+      # class.
+      #
+      # Must appear as first statement in class that mixes in the Attributes
+      # module. Either this method *or* #initialize_attrs should be used, but
+      # not both.
+      def inherit_attrs
+        @copyable_attrs = self.superclass.instance_variable_get(:@copyable_attrs)
+        @schema_attrs = self.superclass.instance_variable_get(:@schema_attrs)
+      end
+
+      # Initializes some class instance variables required to make other
+      # methods in the Attributes module work.
+      #
+      # Must appear as first statement in class that mixes in the Attributes
+      # module. Either this method *or* #initialize_attrs should be used, but
+      # not both.
+      def initialize_attrs
+        @copyable_attrs = []
+        @schema_attrs = {}
+      end
+    end
+
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    # Allows the values of schema attributes to be accessed with a symbol or a
+    # string. So for example, the value of `schema.additional_items` could be
+    # procured with `schema[:additionalItems]`. This only works for attributes
+    # that are part of the JSON schema specification; other methods on the
+    # class are not available (e.g. `expanded`.)
+    #
+    # This is implemented so that `JsonPointer::Evaluator` can evaluate a
+    # reference on an sintance of this class (as well as plain JSON data).
+    def [](name)
+      name = name.to_sym
+      if self.class.schema_attrs.key?(name)
+        send(self.class.schema_attrs[name])
+      else
+        raise NoMethodError, "Schema does not respond to ##{name}"
+      end
+    end
+
+    def copy_from(schema)
+      self.class.copyable_attrs.each do |copyable|
+        instance_variable_set(copyable, schema.instance_variable_get(copyable))
+      end
+    end
+
+    def initialize_schema_attrs
+      self.class.schema_attrs.each do |_, a|
+        send(:"#{a}=", nil)
+      end
+    end
+  end
+end

--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -40,8 +40,8 @@ module JsonSchema
       # Must appear as first statement in class that mixes in (or whose parent
       # mixes in) the Attributes module.
       def inherit_attrs
-        @copyable_attrs = self.superclass.instance_variable_get(:@copyable_attrs)
-        @schema_attrs = self.superclass.instance_variable_get(:@schema_attrs)
+        @copyable_attrs = self.superclass.instance_variable_get(:@copyable_attrs).dup
+        @schema_attrs = self.superclass.instance_variable_get(:@schema_attrs).dup
       end
 
       # Initializes some class instance variables required to make other
@@ -81,9 +81,9 @@ module JsonSchema
       end
     end
 
-    def initialize_schema_attrs
-      self.class.schema_attrs.each do |_, a|
-        send(:"#{a}=", nil)
+    def initialize_attrs
+      self.class.copyable_attrs.each do |a|
+        instance_variable_set(a, nil)
       end
     end
   end

--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -186,6 +186,13 @@ module JsonSchema
           link             = Schema::Link.new
           link.parent      = schema
 
+          link.data        = l
+
+          # any parsed schema is automatically expanded
+          link.expanded    = true
+
+          link.uri         = nil
+
           link.description = l["description"]
           link.enc_type    = l["encType"]
           link.href        = l["href"]

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -162,6 +162,15 @@ module JsonSchema
     attr_schema :path_start, :schema_name => :pathStart
     attr_schema :read_only, :schema_name => :readOnly
 
+    # hyperschema link attributes
+    attr_schema :enc_type
+    attr_schema :href
+    attr_schema :media_type
+    attr_schema :method
+    attr_schema :rel
+    attr_schema :schema
+    attr_schema :target_schema
+
     # Give these properties reader defaults for particular behavior so that we
     # can preserve the `nil` nature of their instance variables. Knowing that
     # these were `nil` when we read them allows us to properly reflect the
@@ -180,6 +189,9 @@ module JsonSchema
     attr_reader_default :properties, {}
     attr_reader_default :strict_properties, false
     attr_reader_default :type, []
+
+    attr_reader_default :enc_type, "application/json"
+    attr_reader_default :media_type, "application/json"
 
     # allow booleans to be access with question mark
     alias :additional_items? :additional_items
@@ -269,18 +281,6 @@ module JsonSchema
     # Link subobject for a hyperschema.
     class Link < Schema
       inherit_attrs
-
-      # hyperschema link attributes
-      attr_schema :enc_type
-      attr_schema :href
-      attr_schema :media_type
-      attr_schema :method
-      attr_schema :rel
-      attr_schema :schema
-      attr_schema :target_schema
-
-      attr_reader_default :enc_type, "application/json"
-      attr_reader_default :media_type, "application/json"
     end
 
     # Media type subobject for a hyperschema.

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -14,8 +14,6 @@ module JsonSchema
       initialize_schema_attrs
     end
 
-    initialize_attrs
-
     # Fragment of a JSON Pointer that can help us build a pointer back to this
     # schema for debugging.
     attr_accessor :fragment

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -1,35 +1,77 @@
 require "json"
 
 module JsonSchema
-  class Schema
-    @@copyable_attrs = []
+  module Attributes
+    module ClassMethods
+      attr_reader :copyable_attrs
 
-    # Attributes that are part of the JSON schema and hyper-schema
-    # specifications. These are allowed to be accessed with the [] operator.
+      # Attributes that are part of the JSON schema and hyper-schema
+      # specifications. These are allowed to be accessed with the [] operator.
+      #
+      # Hash contains the access key mapped to the name of the method that should
+      # be invoked to retrieve a value. For example, `type` maps to `type` and
+      # `additionalItems` maps to `additional_items`.
+      attr_reader :schema_attrs
+
+      # identical to attr_accessible, but allows us to copy in values from a
+      # target schema to help preserve our hierarchy during reference expansion
+      def attr_copyable(attr)
+        attr_accessor(attr)
+        @copyable_attrs ||= []
+        self.copyable_attrs << "@#{attr}".to_sym
+      end
+
+      def attr_schema(attr, options = {})
+        attr_copyable(attr)
+        @schema_attrs ||= {}
+        self.schema_attrs[options[:schema_name] || attr] = attr
+      end
+
+      def attr_reader_default(attr, default)
+        # remove the reader already created by attr_accessor
+        remove_method(attr)
+
+        class_eval("def #{attr} ; !@#{attr}.nil? ? @#{attr} : #{default} ; end")
+      end
+    end
+
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    # Allows the values of schema attributes to be accessed with a symbol or a
+    # string. So for example, the value of `schema.additional_items` could be
+    # procured with `schema[:additionalItems]`. This only works for attributes
+    # that are part of the JSON schema specification; other methods on the
+    # class are not available (e.g. `expanded`.)
     #
-    # Hash contains the access key mapped to the name of the method that should
-    # be invoked to retrieve a value. For example, `type` maps to `type` and
-    # `additionalItems` maps to `additional_items`.
-    @@schema_attrs = {}
-
-    # identical to attr_accessible, but allows us to copy in values from a
-    # target schema to help preserve our hierarchy during reference expansion
-    def self.attr_copyable(attr)
-      attr_accessor(attr)
-      @@copyable_attrs << "@#{attr}".to_sym
+    # This is implemented so that `JsonPointer::Evaluator` can evaluate a
+    # reference on an sintance of this class (as well as plain JSON data).
+    def [](name)
+      name = name.to_sym
+      if self.class.schema_attrs.key?(name)
+        send(self.class.schema_attrs[name])
+      else
+        raise NoMethodError, "Schema does not respond to ##{name}"
+      end
     end
 
-    def self.attr_schema(attr, options = {})
-      attr_copyable(attr)
-      @@schema_attrs[options[:schema_name] || attr] = attr
+    def copy_from(schema)
+      self.class.copyable_attrs.each do |copyable|
+        instance_variable_set(copyable, schema.instance_variable_get(copyable))
+      end
     end
 
-    def self.attr_reader_default(attr, default)
-      # remove the reader already created by attr_accessor
-      remove_method(attr)
 
-      class_eval("def #{attr} ; !@#{attr}.nil? ? @#{attr} : #{default} ; end")
+    def initialize_schema_attrs
+      self.class.schema_attrs.each do |_, a|
+        send(:"#{a}=", nil)
+      end
     end
+  end
+
+  class Schema
+    include Attributes
 
     def initialize
       @clones = Set.new
@@ -38,9 +80,7 @@ module JsonSchema
       # schema instance without going through the parser and validate against
       # it without Ruby throwing warnings about uninitialized instance
       # variables.
-      @@schema_attrs.each do |_, a|
-        send(:"#{a}=", nil)
-      end
+      initialize_schema_attrs
     end
 
     # Fragment of a JSON Pointer that can help us build a pointer back to this
@@ -94,12 +134,13 @@ module JsonSchema
     # Type: String
     attr_schema :id
 
-    # Short title of the schema.
+    # Short title of the schema (or the hyper-schema link if this is one).
     #
     # Type: String
     attr_schema :title
 
-    # More detailed description of the schema.
+    # More detailed description of the schema (or the hyper-schema link if this
+    # is one).
     #
     # Type: String
     attr_schema :description
@@ -191,6 +232,15 @@ module JsonSchema
     attr_schema :path_start, :schema_name => :pathStart
     attr_schema :read_only, :schema_name => :readOnly
 
+    # hyperschema link attributes
+    attr_schema :enc_type
+    attr_schema :href
+    attr_schema :media_type
+    attr_schema :method
+    attr_schema :rel
+    attr_schema :schema
+    attr_schema :target_schema
+
     # Give these properties reader defaults for particular behavior so that we
     # can preserve the `nil` nature of their instance variables. Knowing that
     # these were `nil` when we read them allows us to properly reflect the
@@ -210,6 +260,9 @@ module JsonSchema
     attr_reader_default :strict_properties, false
     attr_reader_default :type, []
 
+    attr_reader_default :enc_type, "application/json"
+    attr_reader_default :media_type, "application/json"
+
     # allow booleans to be access with question mark
     alias :additional_items? :additional_items
     alias :expanded? :expanded
@@ -217,29 +270,6 @@ module JsonSchema
     alias :min_exclusive? :min_exclusive
     alias :read_only? :read_only
     alias :unique_items? :unique_items
-
-    # Allows the values of schema attributes to be accessed with a symbol or a
-    # string. So for example, the value of `schema.additional_items` could be
-    # procured with `schema[:additionalItems]`. This only works for attributes
-    # that are part of the JSON schema specification; other methods on the
-    # class are not available (e.g. `expanded`.)
-    #
-    # This is implemented so that `JsonPointer::Evaluator` can evaluate a
-    # reference on an sintance of this class (as well as plain JSON data).
-    def [](name)
-      name = name.to_sym
-      if @@schema_attrs.key?(name)
-        send(@@schema_attrs[name])
-      else
-        raise NoMethodError, "Schema does not respond to ##{name}"
-      end
-    end
-
-    def copy_from(schema)
-      @@copyable_attrs.each do |copyable|
-        instance_variable_set(copyable, schema.instance_variable_get(copyable))
-      end
-    end
 
     def expand_references(options = {})
       expander = ReferenceExpander.new
@@ -267,7 +297,7 @@ module JsonSchema
         str
       else
         hash = {}
-        @@copyable_attrs.each do |copyable|
+        self.class.copyable_attrs.each do |copyable|
           next if [:@clones, :@data, :@parent, :@uri].include?(copyable)
           if value = instance_variable_get(copyable)
             if value.is_a?(Array)
@@ -319,28 +349,7 @@ module JsonSchema
     end
 
     # Link subobject for a hyperschema.
-    class Link
-      attr_accessor :parent
-
-      # schema attributes
-      attr_accessor :description
-      attr_writer :enc_type
-      attr_accessor :href
-      attr_writer :media_type
-      attr_accessor :method
-      attr_accessor :rel
-      attr_accessor :schema
-      attr_accessor :target_schema
-      attr_accessor :title
-
-      def enc_type
-        @enc_type || "application/json"
-      end
-
-      def media_type
-        @media_type || "application/json"
-      end
-    end
+    Link = Schema
 
     # Media type subobject for a hyperschema.
     class Media

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -5,13 +5,12 @@ module JsonSchema
     include Attributes
 
     def initialize
-      @clones = Set.new
+      # nil out all our fields so that it's possible to instantiate a schema
+      # instance without going through the parser and validate against it
+      # without Ruby throwing warnings about uninitialized instance variables.
+      initialize_attrs
 
-      # nil out all our schema fields so that it's possible to instantiate a
-      # schema instance without going through the parser and validate against
-      # it without Ruby throwing warnings about uninitialized instance
-      # variables.
-      initialize_schema_attrs
+      @clones = Set.new
     end
 
     # Fragment of a JSON Pointer that can help us build a pointer back to this
@@ -163,15 +162,6 @@ module JsonSchema
     attr_schema :path_start, :schema_name => :pathStart
     attr_schema :read_only, :schema_name => :readOnly
 
-    # hyperschema link attributes
-    attr_schema :enc_type
-    attr_schema :href
-    attr_schema :media_type
-    attr_schema :method
-    attr_schema :rel
-    attr_schema :schema
-    attr_schema :target_schema
-
     # Give these properties reader defaults for particular behavior so that we
     # can preserve the `nil` nature of their instance variables. Knowing that
     # these were `nil` when we read them allows us to properly reflect the
@@ -190,9 +180,6 @@ module JsonSchema
     attr_reader_default :properties, {}
     attr_reader_default :strict_properties, false
     attr_reader_default :type, []
-
-    attr_reader_default :enc_type, "application/json"
-    attr_reader_default :media_type, "application/json"
 
     # allow booleans to be access with question mark
     alias :additional_items? :additional_items
@@ -282,6 +269,18 @@ module JsonSchema
     # Link subobject for a hyperschema.
     class Link < Schema
       inherit_attrs
+
+      # hyperschema link attributes
+      attr_schema :enc_type
+      attr_schema :href
+      attr_schema :media_type
+      attr_schema :method
+      attr_schema :rel
+      attr_schema :schema
+      attr_schema :target_schema
+
+      attr_reader_default :enc_type, "application/json"
+      attr_reader_default :media_type, "application/json"
     end
 
     # Media type subobject for a hyperschema.

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -409,8 +409,9 @@ module JsonSchema
 
       num_valid = schema.one_of.count do |subschema|
         current_sub_errors = []
+        valid = validate_data(subschema, data, current_sub_errors, path)
         sub_errors << current_sub_errors
-        validate_data(subschema, data, current_sub_errors, path)
+        valid
       end
 
       return true if num_valid == 1

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+require "json_schema"
+
+describe JsonSchema::Attributes do
+  it "defines copyable attributes" do
+    obj = TestAttributes.new
+    obj.copyable = "foo"
+    assert_equal "foo", obj.copyable
+    assert_includes obj.class.copyable_attrs, :@copyable
+  end
+
+  it "defines schema attributes" do
+    obj = TestAttributes.new
+    obj.schema = "foo"
+    assert_equal "foo", obj.schema
+    assert_equal({:schema => :schema, :named => :schema_named},
+      obj.class.schema_attrs)
+  end
+
+  it "defines attributes with default readers" do
+    obj = TestAttributes.new
+    assert_equal [], obj.copyable_default
+  end
+
+  it "inherits attributes when so instructed" do
+    obj = TestAttributesDescendant.new
+    assert_includes obj.class.copyable_attrs, :@copyable
+  end
+
+  it "allows schema attributes to be indexed but not others" do
+    obj = TestAttributes.new
+
+    obj.copyable = "non-schema"
+    obj.schema = "schema"
+
+    assert_raises NoMethodError do
+      assert_equal nil, obj[:copyable]
+    end
+
+    assert_equal "schema", obj[:schema]
+  end
+
+  it "copies attributes with #copy_from" do
+    obj = TestAttributes.new
+
+    obj.copyable = "copyable"
+    obj.schema = "schema"
+
+    obj2 = TestAttributes.new
+    obj2.copy_from(obj)
+
+    assert_equal "copyable", obj2.copyable
+    assert_equal "schema", obj2.schema
+  end
+
+  it "initializes attributes with #initialize_attrs" do
+    obj = TestAttributes.new
+
+    # should produce a nil value *without* a Ruby warning
+    assert_equal nil, obj.copyable
+    assert_equal nil, obj.schema
+  end
+
+  class TestAttributes
+    include JsonSchema::Attributes
+
+    def initialize
+      initialize_attrs
+    end
+
+    attr_copyable :copyable
+
+    attr_schema :schema
+    attr_schema :schema_named, :schema_name => :named
+
+    attr_copyable :copyable_default
+    attr_reader_default :copyable_default, []
+  end
+
+  class TestAttributesDescendant < TestAttributes
+    inherit_attrs
+  end
+end

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -265,6 +265,13 @@ describe JsonSchema::ReferenceExpander do
     assert schema.expanded?
   end
 
+  it "expands a reference to a link" do
+    pointer("#/properties").merge!(
+      "link" => { "$ref" => "#/links/0" }
+    )
+    assert expand
+  end
+
   def error_messages
     @expander.errors.map { |e| e.message }
   end

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -270,6 +270,11 @@ describe JsonSchema::ReferenceExpander do
       "link" => { "$ref" => "#/links/0" }
     )
     assert expand
+
+    referenced = @schema.links[0]
+    reference = @schema.properties["link"]
+
+    assert_equal reference.href, referenced.href
   end
 
   def error_messages


### PR DESCRIPTION
As described in #79, a change that I'd put in improve and optimize reference expansion in #75 unfortunately had the effect of breaking expansion when it came to hyper-schema links.

This patch corrects that problem by making links behave more like schemas so that they can be hydrated from a different reference object just like a schema can. Also adds a new `Attributes` module to better extract and test attribute handling.

The only unusual part of the implementation is that I had to move `Link` attributes into the `Schema` class so that it's possible to copy them over when expanding a reference. The old `Link` class still works as before though, so this change is backward compatible.

Fixes #79.