### PR TITLE
Smarter defaults for attributes

### DIFF
--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -22,18 +22,16 @@ module JsonSchema
 
       # identical to attr_accessible, but allows us to copy in values from a
       # target schema to help preserve our hierarchy during reference expansion
-      def attr_copyable(attr)
+      def attr_copyable(attr, options = {})
         attr_accessor(attr)
-        self.copyable_attrs["@#{attr}".to_sym] = nil
+
+        # Usually the default being assigned here is nil.
+        self.copyable_attrs["@#{attr}".to_sym] = options[:default]
       end
 
       def attr_schema(attr, options = {})
-        attr_copyable(attr)
+        attr_copyable(attr, :default => options[:default])
         self.schema_attrs[options[:schema_name] || attr] = attr
-      end
-
-      def attr_reader_default(attr, default)
-        self.copyable_attrs["@#{attr}".to_sym] = default
       end
 
       # Directive indicating that attributes should be inherited from a parent

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -254,10 +254,12 @@ module JsonSchema
           each { |s| yielder << s }
 
         # schemas contained inside hyper-schema links objects
-        schema.links.map { |l| [l.schema, l.target_schema] }.
-          flatten.
-          compact.
-          each { |s| yielder << s }
+        if schema.links
+          schema.links.map { |l| [l.schema, l.target_schema] }.
+            flatten.
+            compact.
+            each { |s| yielder << s }
+        end
       end
     end
 

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -9,6 +9,11 @@ module JsonSchema
       # instance without going through the parser and validate against it
       # without Ruby throwing warnings about uninitialized instance variables.
       initialize_attrs
+
+      # Don't put this in as an attribute default. We require that this precise
+      # pointer gets copied between all clones of any given schema so that they
+      # all share exactly the same set.
+      @clones = Set.new
     end
 
     # Fragment of a JSON Pointer that can help us build a pointer back to this
@@ -41,8 +46,11 @@ module JsonSchema
     # initialized after the original. Used for JSON Reference expansion. The
     # only copy not present in this set is the original Schema object.
     #
+    # Note that this doesn't have a default option because we rely on the fact
+    # that the set is the *same object* between all clones of any given schema.
+    #
     # Type: Set[Schema]
-    attr_copyable :clones, :default => Set.new
+    attr_copyable :clones
 
     # The normalized URI of this schema. Note that child schemas inherit a URI
     # from their parent unless they have one explicitly defined, so this is
@@ -203,7 +211,7 @@ module JsonSchema
         str
       else
         hash = {}
-        self.class.copyable_attrs.each do |copyable|
+        self.class.copyable_attrs.each do |copyable, _|
           next if [:@clones, :@data, :@parent, :@uri].include?(copyable)
           if value = instance_variable_get(copyable)
             if value.is_a?(Array)

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -9,8 +9,6 @@ module JsonSchema
       # instance without going through the parser and validate against it
       # without Ruby throwing warnings about uninitialized instance variables.
       initialize_attrs
-
-      @clones = Set.new
     end
 
     # Fragment of a JSON Pointer that can help us build a pointer back to this
@@ -179,6 +177,7 @@ module JsonSchema
     attr_reader_default :additional_properties, true
     attr_reader_default :all_of, []
     attr_reader_default :any_of, []
+    attr_reader_default :clones, Set.new
     attr_reader_default :definitions, {}
     attr_reader_default :dependencies, {}
     attr_reader_default :links, []

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -42,7 +42,7 @@ module JsonSchema
     # only copy not present in this set is the original Schema object.
     #
     # Type: Set[Schema]
-    attr_copyable :clones
+    attr_copyable :clones, :default => Set.new
 
     # The normalized URI of this schema. Note that child schemas inherit a URI
     # from their parent unless they have one explicitly defined, so this is
@@ -86,19 +86,19 @@ module JsonSchema
     # set of to be valid.
     #
     # Type: Array[Schema]
-    attr_schema :all_of, :schema_name => :allOf
+    attr_schema :all_of, :default => [], :schema_name => :allOf
 
     # A collection of subschemas of which data must validate against any schema
     # in the set to be be valid.
     #
     # Type: Array[Schema]
-    attr_schema :any_of, :schema_name => :anyOf
+    attr_schema :any_of, :default => [], :schema_name => :anyOf
 
     # A collection of inlined subschemas. Standard convention is to subschemas
     # here and reference them from elsewhere.
     #
     # Type: Hash[String => Schema]
-    attr_schema :definitions
+    attr_schema :definitions, :default => {}
 
     # A collection of objects that must include the data for it to be valid.
     #
@@ -109,7 +109,7 @@ module JsonSchema
     # one of to be valid.
     #
     # Type: Array[Schema]
-    attr_schema :one_of, :schema_name => :oneOf
+    attr_schema :one_of, :default => [], :schema_name => :oneOf
 
     # A subschema which data must not validate against to be valid.
     #
@@ -121,10 +121,10 @@ module JsonSchema
     # of strings.
     #
     # Type: Array[String]
-    attr_schema :type
+    attr_schema :type, :default => []
 
     # validation: array
-    attr_schema :additional_items, :schema_name => :additionalItems
+    attr_schema :additional_items, :default => true, :schema_name => :additionalItems
     attr_schema :items
     attr_schema :max_items, :schema_name => :maxItems
     attr_schema :min_items, :schema_name => :minItems
@@ -132,21 +132,21 @@ module JsonSchema
 
     # validation: number/integer
     attr_schema :max
-    attr_schema :max_exclusive, :schema_name => :maxExclusive
+    attr_schema :max_exclusive, :default => false, :schema_name => :maxExclusive
     attr_schema :min
-    attr_schema :min_exclusive, :schema_name => :minExclusive
+    attr_schema :min_exclusive, :default => false, :schema_name => :minExclusive
     attr_schema :multiple_of, :schema_name => :multipleOf
 
     # validation: object
-    attr_schema :additional_properties, :schema_name => :additionalProperties
-    attr_schema :dependencies
+    attr_schema :additional_properties, :default => true, :schema_name => :additionalProperties
+    attr_schema :dependencies, :default => {}
     attr_schema :max_properties, :schema_name => :maxProperties
     attr_schema :min_properties, :schema_name => :minProperties
-    attr_schema :pattern_properties, :schema_name => :patternProperties
-    attr_schema :properties
+    attr_schema :pattern_properties, :default => {}, :schema_name => :patternProperties
+    attr_schema :properties, :default => {}
     attr_schema :required
     # warning: strictProperties is technically V5 spec (but I needed it now)
-    attr_schema :strict_properties, :schema_name => :strictProperties
+    attr_schema :strict_properties, :default => false, :schema_name => :strictProperties
 
     # validation: string
     attr_schema :format
@@ -155,42 +155,19 @@ module JsonSchema
     attr_schema :pattern
 
     # hyperschema
-    attr_schema :links
+    attr_schema :links, :default => []
     attr_schema :media
     attr_schema :path_start, :schema_name => :pathStart
     attr_schema :read_only, :schema_name => :readOnly
 
     # hyperschema link attributes
-    attr_schema :enc_type
+    attr_schema :enc_type, :default => "application/json"
     attr_schema :href
-    attr_schema :media_type
+    attr_schema :media_type, :default => "application/json"
     attr_schema :method
     attr_schema :rel
     attr_schema :schema
     attr_schema :target_schema
-
-    # Give these properties reader defaults for particular behavior so that we
-    # can preserve the `nil` nature of their instance variables. Knowing that
-    # these were `nil` when we read them allows us to properly reflect the
-    # parsed schema back to JSON.
-    attr_reader_default :additional_items, true
-    attr_reader_default :additional_properties, true
-    attr_reader_default :all_of, []
-    attr_reader_default :any_of, []
-    attr_reader_default :clones, Set.new
-    attr_reader_default :definitions, {}
-    attr_reader_default :dependencies, {}
-    attr_reader_default :links, []
-    attr_reader_default :one_of, []
-    attr_reader_default :max_exclusive, false
-    attr_reader_default :min_exclusive, false
-    attr_reader_default :pattern_properties, {}
-    attr_reader_default :properties, {}
-    attr_reader_default :strict_properties, false
-    attr_reader_default :type, []
-
-    attr_reader_default :enc_type, "application/json"
-    attr_reader_default :media_type, "application/json"
 
     # allow booleans to be access with question mark
     alias :additional_items? :additional_items

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -499,7 +499,7 @@ module JsonSchema
     end
 
     def validate_type(schema, data, errors, path)
-      return true if schema.type.empty?
+      return true if !schema.type || schema.type.empty?
       valid_types = schema.type.map { |t| TYPE_MAP[t] }.flatten.compact
       if valid_types.any? { |t| data.is_a?(t) }
         true

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -21,6 +21,19 @@ describe JsonSchema::Attributes do
   it "defines attributes with default readers" do
     obj = TestAttributes.new
     assert_equal [], obj.copyable_default
+
+    assert_equal "application/json", obj.copyable_default_with_string
+
+    hash = obj.copyable_default_with_object
+    assert_equal({}, hash)
+    hash[:x] = 123
+
+    # This is a check to make sure that the new object is not the same object
+    # as the one that we just mutated above. When assigning defaults the module
+    # should dup any common data strcutures that it puts in here.
+    obj = TestAttributes.new
+    hash = obj.copyable_default_with_object
+    assert_equal({}, hash)
   end
 
   it "inherits attributes when so instructed" do
@@ -76,6 +89,12 @@ describe JsonSchema::Attributes do
 
     attr_copyable :copyable_default
     attr_reader_default :copyable_default, []
+
+    attr_copyable :copyable_default_with_string
+    attr_reader_default :copyable_default_with_string, "application/json"
+
+    attr_copyable :copyable_default_with_object
+    attr_reader_default :copyable_default_with_object, {}
   end
 
   class TestAttributesDescendant < TestAttributes

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -87,14 +87,9 @@ describe JsonSchema::Attributes do
     attr_schema :schema
     attr_schema :schema_named, :schema_name => :named
 
-    attr_copyable :copyable_default
-    attr_reader_default :copyable_default, []
-
-    attr_copyable :copyable_default_with_string
-    attr_reader_default :copyable_default_with_string, "application/json"
-
-    attr_copyable :copyable_default_with_object
-    attr_reader_default :copyable_default_with_object, {}
+    attr_copyable :copyable_default, :default => []
+    attr_copyable :copyable_default_with_string, :default => "application/json"
+    attr_copyable :copyable_default_with_object, :default => {}
   end
 
   class TestAttributesDescendant < TestAttributes


### PR DESCRIPTION
Change out the attribute default implementation for one that's a little smarter and more cleanly implemented in the Schema class.

The trouble with the current one is that it can't handle a string value for a default because it uses a string itself combined with an eval. This didn't play nicely with the new field definitions for hyper-schemas introduced in #80.

Also adds some new test assertions to help identity a future regression of this issue.