### PR TITLE
Assign links a fragment so they can be inspected

### DIFF
--- a/lib/json_schema/parser.rb
+++ b/lib/json_schema/parser.rb
@@ -185,6 +185,7 @@ module JsonSchema
         schema.links = schema.links.each_with_index.map { |l, i|
           link             = Schema::Link.new
           link.parent      = schema
+          link.fragment    = "links/#{i}"
 
           link.data        = l
 

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -198,6 +198,8 @@ describe JsonSchema::Parser do
     schema = parse.definitions["app"]
     link = schema.links[0]
     assert_equal schema, link.parent
+    assert_equal "links/0", link.fragment
+    assert_equal "#/definitions/app/links/0", link.pointer
     assert_equal "Create a new app.", link.description
     assert_equal "application/x-www-form-urlencoded", link.enc_type
     assert_equal "/apps", link.href


### PR DESCRIPTION
Previously, links were not being assigned a fragment (but were assigned
a parent) so if `#inspect` (which calls `#pointer`) was invoked on them,
we'd throw an exception as we tried to concatenate a string to `nil`.

This patch addresses that issue by having the parser assign links a
fragment so that a pointer can successfully be built for them.

Fixes #82.