### PR TITLE
Configuration all_of_sub_errors makes allOf include sub-errors

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -39,6 +39,6 @@ which is human-readable and contains information for the developer, and a
 * `required_failed`: some `required` keys weren't included
 * `unique_items_failed`: array contained duplicates, disallowed by `"uniqueItems": true`
 
-`ValidationError`s from `anyOf` and `oneOf` will also populate `sub_errors` on the error
-object. This is an array of arrays, with each sub-array containing the validation errors
-for each subschema.
+`ValidationError`s from `allOf` (only if `all_of_sub_errors` is configured as true), `anyOf`, and `oneOf` will
+also populate `sub_errors` on the error object. This is an array of arrays, with each sub-array containing the
+validation errors for each subschema.

--- a/lib/json_schema/configuration.rb
+++ b/lib/json_schema/configuration.rb
@@ -2,6 +2,7 @@ module JsonSchema
   class Configuration
     attr_reader :custom_formats
     attr_reader :validate_regex_with
+    attr_accessor :all_of_sub_errors
 
     def validate_regex_with=(validator)
       @validate_regex_with = validator
@@ -15,6 +16,7 @@ module JsonSchema
     def reset!
       @validate_regex_with = nil
       @custom_formats = {}
+      @all_of_sub_errors = false
     end
 
     private


### PR DESCRIPTION
In our team's use of `JsonSchema` we found it useful to include the validation errors for `allOf` under `sub_errors`. As not to change the default behavior, which includes errors on the same level and stops after encountering the first error, this change is available via a configuration attribute that is `false` by default. Please take a look! Thank you.