### PR TITLE
Return missing required fields as data

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -503,7 +503,7 @@ module JsonSchema
         message = %{"#{missing.sort.join('", "')}" } +
           (missing.length == 1 ? "wasn't" : "weren't") +
           %{ supplied.}
-        errors << ValidationError.new(schema, path, message, :required_failed)
+        errors << ValidationError.new(schema, path, message, :required_failed, data: missing)
         false
       end
     end

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -566,6 +566,7 @@ describe JsonSchema::Validator do
     refute validate
     assert_includes error_messages, %{"name" wasn't supplied.}
     assert_includes error_types, :required_failed
+    assert_includes error_data, ["name"]
   end
 
   it "validates strictProperties successfully" do


### PR DESCRIPTION
I'm developing an app and I need to have the validation messages translated using I18n, but only for the 'required' validation we don't have any 'data' to help me translate the messages.