### PR TITLE
Add schema_name for max/min + fix others

### DIFF
--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -139,10 +139,10 @@ module JsonSchema
     attr_schema :unique_items, :schema_name => :uniqueItems
 
     # validation: number/integer
-    attr_schema :max
-    attr_schema :max_exclusive, :default => false, :schema_name => :maxExclusive
-    attr_schema :min
-    attr_schema :min_exclusive, :default => false, :schema_name => :minExclusive
+    attr_schema :max, :schema_name => :maximum
+    attr_schema :max_exclusive, :default => false, :schema_name => :exclusiveMaximum
+    attr_schema :min, :schema_name => :minimum
+    attr_schema :min_exclusive, :default => false, :schema_name => :exclusiveMinimum
     attr_schema :multiple_of, :schema_name => :multipleOf
 
     # validation: object


### PR DESCRIPTION
Adds a schema name for the `max` and `min` properties of a schema so
that when we index them with `#[]`, we'll get back the value that we
expect (for example, maximum should be accessible with `[:maximum]`.

Also fix the schema names for `max_exclusive` and `min_exclusive` which
were entered incorrectly.

Fixes #87.