### PR TITLE
Add Ruby 2.4.1 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.1
 
 script: bundle exec rake
 


### PR DESCRIPTION
We may as well have the most recent version of Ruby in here as well.