### PR TITLE
Add support for `uri-reference` format

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -567,6 +567,15 @@ module JsonSchema
       "ipv6" => ->(data) { data =~ IPV6_PATTERN },
       "regex" => ->(data) { Regexp.new(data) rescue false },
       "uri" => ->(data) { URI.parse(data) rescue false },
+
+      # From the spec: a string instance is valid URI Reference (either a URI
+      # or a relative-reference), according to RFC3986.
+      #
+      # URI.parse will a handle a relative reference as well as an absolute
+      # one. Really though we should try to make "uri" more restrictive, and
+      # both of these could do to be more robust.
+      "uri-reference" => ->(data) { URI.parse(data) rescue false },
+
       "uuid" => ->(data) { data =~ UUID_PATTERN },
     }.freeze
 

--- a/test/json_schema/parser_test.rb
+++ b/test/json_schema/parser_test.rb
@@ -285,7 +285,8 @@ describe JsonSchema::Parser do
     refute parse
     assert_includes error_messages, '"obscure-thing" is not a valid format, ' \
                                     'must be one of date, date-time, email, ' \
-                                    'hostname, ipv4, ipv6, regex, uri, uuid.'
+                                    'hostname, ipv4, ipv6, regex, uri, ' \
+                                    'uri-reference, uuid.'
     assert_includes error_types, :unknown_format
   end
 
@@ -321,8 +322,8 @@ describe JsonSchema::Parser do
     refute parse
     assert_includes error_messages, '"not-a-format" is not a valid format, ' \
                                     'must be one of date, date-time, email, ' \
-                                    'hostname, ipv4, ipv6, regex, uri, uuid, ' \
-                                    'the-answer.'
+                                    'hostname, ipv4, ipv6, regex, uri, ' \
+                                    'uri-reference, uuid, the-answer.'
     assert_includes error_types, :unknown_format
   end
 

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -867,6 +867,32 @@ describe JsonSchema::Validator do
     assert_includes error_types, :invalid_format
   end
 
+  it "validates absolute uri-reference format successfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "uri-reference"
+    )
+    data_sample["owner"] = "https://example.com"
+    assert validate
+  end
+
+  it "validates relative uri format successfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "uri"
+    )
+    data_sample["owner"] = "#hello"
+    assert validate
+  end
+
+  it "validates uri format unsuccessfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "uri-reference"
+    )
+    data_sample["owner"] = "http://example.com[]"
+    refute validate
+    assert_includes error_messages, %{http://example.com[] is not a valid uri-reference.}
+    assert_includes error_types, :invalid_format
+  end
+
   it "validates uuid format successfully" do
     pointer("#/definitions/app/definitions/owner").merge!(
       "format" => "uuid"


### PR DESCRIPTION
Adds support for the `uri-reference` format. From the spec:

> This attribute applies to string instances.
>
> A string instance is valid against this attribute if it is a valid URI
> Reference (either a URI or a relative-reference), according to
> RFC3986.