### PR TITLE
use flap_map for a small performance gain

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -517,7 +517,7 @@ module JsonSchema
 
     def validate_type(schema, data, errors, path)
       return true if !schema.type || schema.type.empty?
-      valid_types = schema.type.map { |t| TYPE_MAP[t] }.flatten.compact
+      valid_types = schema.type.flat_map { |t| TYPE_MAP[t] }.compact
       if valid_types.any? { |t| data.is_a?(t) }
         true
       else


### PR DESCRIPTION
On a not-too-complex schema, validating a 15 MB JSON file, the `flat_map` saves roughly 3% processing time.

Total time (seconds) for 40 validation runs of the same file. Loading the schema and parsing the file were not part of the test run:
```
      user     system      total        real
475.880000   0.070000 475.950000 (476.523519)  current
461.270000   0.060000 461.330000 (461.930364)  flat_map
```
