### PR TITLE
avoid allocations in attr_copyable for decent speedup

### DIFF
--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -25,23 +25,21 @@ module JsonSchema
       def attr_copyable(attr, options = {})
         attr_accessor(attr)
 
+        ref = :"@#{attr}"
         # Usually the default being assigned here is nil.
-        self.copyable_attrs["@#{attr}".to_sym] = options[:default]
+        self.copyable_attrs[ref] = options[:default]
 
         if default = options[:default]
           # remove the reader already created by attr_accessor
           remove_method(attr)
 
+          need_dup = [Array, Hash, Set].include?(default.class)
           define_method(attr) do
-            val = instance_variable_get(:"@#{attr}")
+            val = instance_variable_get(ref)
             if !val.nil?
               val
             else
-              if [Array, Hash, Set].include?(default.class)
-                default.dup
-              else
-                default
-              end
+              need_dup ? default.class.new : default
             end
           end
         end


### PR DESCRIPTION
The speedup mostly comes from moving repeated work out of the custom attribute reader into `attr_copyable` and only doing it once. 

Timings:
```
# format: m:ss.milliseconds (from "time" real column)
1:27.66 1:24.10 1:25.08  # without patch
1:24.62 1:20.59 1:20.05  # just pulling out "need dup" check
1:00.02 0:59.08 0:56.66  # just pulling out :"@#{attr}"
1:24.98 1:24.95 1:22.78  # just replacing .dup with .class.new
0:54.67 0:56.95 0:55.93  # with patch (=all three)
```

Using Ruby 2.5 with `bin/validate-schema schema.json data.json`, so includes parsing.

Schema used: https://github.com/fge/sample-json-schemas/blob/master/json-patch/json-patch.json
sample data:
```
[
 { "op": "test", "path": "/baz", "value": "qux" },
 { "op": "test", "path": "/foo/1", "value": 2 },
 # repeated to get an ~28 MB file
]
```

Moving `[Array, Hash, Set]` to the class and/or making it a Set/Hash yields no measurable improvement for this workload. It's also not faster to define different methods for the dup/non-dup cases.

Also, I'm not sure that `class.new` actually saves any time, since it's so close to the other result. I'd have to do more testing and proper statistics. I can change that back to `.dup` if desired.

