### PR TITLE
early return for "anyOf" validator

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -172,22 +172,17 @@ module JsonSchema
     def validate_any_of(schema, data, errors, path)
       return true if schema.any_of.empty?
 
-      sub_errors = []
-
-      subschemata_validity = schema.any_of.map do |subschema|
+      sub_errors = schema.any_of.map do |subschema|
         current_sub_errors = []
-        sub_errors << current_sub_errors
-        validate_data(subschema, data, current_sub_errors, path)
+        return true if validate_data(subschema, data, current_sub_errors, path)
+        current_sub_errors
       end
 
-      unless subschemata_validity.any? { |valid| valid == true }
-        message = %{No subschema in "anyOf" matched.}
-        errors << ValidationError.new(schema, path, message, :any_of_failed,
-          sub_errors: sub_errors, data: data)
-        return false
-      end
+      message = %{No subschema in "anyOf" matched.}
+      errors << ValidationError.new(schema, path, message, :any_of_failed,
+        sub_errors: sub_errors, data: data)
 
-      true
+      false
     end
 
     def validate_dependencies(schema, data, errors, path)


### PR DESCRIPTION
There is no need to go through all candidates as soon as we find the first suitable one for the `anyOf` validator. Using a similar schema as in #92 and with the patches from #92 I get the following times:

```
0:55.24 0:56.67 0:57.17 # baseline
0:57.92 0:56.92 0:56.93 # with patch, but valid "anyOf" item is last
0:18.62 0:18.55 0:18.31 # with patch, but valid "anyOf" item is first (skips 5 invalid validations)
```

The patch is obviously circumstantial, but it doesn't incur any functional changes.