### PR TITLE
precalculate valid Ruby types to speed up validation

### DIFF
--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -43,10 +43,18 @@ module JsonSchema
             end
           end
         end
+
+        if options[:clear_cache]
+          remove_method(:"#{attr}=")
+          define_method(:"#{attr}=") do |value|
+            instance_variable_set(options[:clear_cache], nil)
+            instance_variable_set(ref, value)
+          end
+        end
       end
 
       def attr_schema(attr, options = {})
-        attr_copyable(attr, :default => options[:default])
+        attr_copyable(attr, :default => options[:default], :clear_cache => options[:clear_cache])
         self.schema_attrs[options[:schema_name] || attr] = attr
       end
 

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -139,7 +139,7 @@ module JsonSchema
     # of strings.
     #
     # Type: Array[String]
-    attr_schema :type, :default => []
+    attr_schema :type, :default => [], :clear_cache => :@type_parsed
 
     # validation: array
     attr_schema :additional_items, :default => true, :schema_name => :additionalItems

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -2,6 +2,16 @@ require "json"
 
 module JsonSchema
   class Schema
+    TYPE_MAP = {
+      "array"   => Array,
+      "boolean" => [FalseClass, TrueClass],
+      "integer" => Integer,
+      "number"  => [Integer, Float],
+      "null"    => NilClass,
+      "object"  => Hash,
+      "string"  => String,
+    }
+
     include Attributes
 
     def initialize
@@ -197,6 +207,14 @@ module JsonSchema
     def expand_references!(options = {})
       ReferenceExpander.new.expand!(self, options)
       true
+    end
+
+    # An array of Ruby classes that are equivalent to the types defined in the
+    # schema.
+    #
+    # Type: Array[Class]
+    def type_parsed
+      @type_parsed ||= type.flat_map { |t| TYPE_MAP[t] }.compact
     end
 
     def inspect

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -2,16 +2,6 @@ require "uri"
 
 module JsonSchema
   class Validator
-    TYPE_MAP = {
-      "array"   => Array,
-      "boolean" => [FalseClass, TrueClass],
-      "integer" => Integer,
-      "number"  => [Integer, Float],
-      "null"    => NilClass,
-      "object"  => Hash,
-      "string"  => String,
-    }
-
     attr_accessor :errors
 
     def initialize(schema)
@@ -511,9 +501,8 @@ module JsonSchema
     end
 
     def validate_type(schema, data, errors, path)
-      return true if !schema.type || schema.type.empty?
-      valid_types = schema.type.flat_map { |t| TYPE_MAP[t] }.compact
-      if valid_types.any? { |t| data.is_a?(t) }
+      return true if schema.type.empty?
+      if schema.type_parsed.include?(data.class)
         true
       else
         key = find_parent(schema)

--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -501,7 +501,7 @@ module JsonSchema
     end
 
     def validate_type(schema, data, errors, path)
-      return true if schema.type.empty?
+      return true if !schema.type || schema.type.empty?
       if schema.type_parsed.include?(data.class)
         true
       else

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -14,7 +14,7 @@ describe JsonSchema::Attributes do
     obj = TestAttributes.new
     obj.schema = "foo"
     assert_equal "foo", obj.schema
-    assert_equal({:schema => :schema, :named => :schema_named},
+    assert_equal({:schema => :schema, :named => :schema_named, :cached => :cached},
       obj.class.schema_attrs)
   end
 
@@ -75,6 +75,16 @@ describe JsonSchema::Attributes do
     assert_equal nil, obj.schema
   end
 
+  it "cleans cached values when assigning parent attribute" do
+    obj = TestAttributes.new
+
+    obj.cached = "test"
+    assert_equal "test_123", obj.cached_parsed
+
+    obj.cached = "other"
+    assert_equal "other_123", obj.cached_parsed
+  end
+
   class TestAttributes
     include JsonSchema::Attributes
 
@@ -86,6 +96,11 @@ describe JsonSchema::Attributes do
 
     attr_schema :schema
     attr_schema :schema_named, :schema_name => :named
+
+    attr_schema :cached, :clear_cache => :@cached_parsed
+    def cached_parsed
+      @cached_parsed ||= "#{cached}_123"
+    end
 
     attr_copyable :copyable_default, :default => []
     attr_copyable :copyable_default_with_string, :default => "application/json"

--- a/test/json_schema/schema_test.rb
+++ b/test/json_schema/schema_test.rb
@@ -34,4 +34,13 @@ describe JsonSchema::Schema do
       schema[:expanded]
     end
   end
+
+  it "updates type_parsed when type is changed" do
+    schema = JsonSchema::Schema.new
+    schema.type = ["integer"]
+    assert_equal [Integer], schema.type_parsed
+
+    schema.type = ["string"]
+    assert_equal [String], schema.type_parsed
+  end
 end


### PR DESCRIPTION
Right now, `validate_type` always rebuilds the array of valid Ruby types from the list of valid JSON schema types. Unsurprisingly caching helps (~10% speedup):
```
8,941 8,869 8,639 8,713 9,030 vanilla
8,026 7,966 7,914 7,951 8,030 pre-calculate types
```

The patch is not clearing the cache if the types get re-assigned, although it would be easy enough to add. In general I am unsure if this is a worthwhile tradeoff – the previous patches were mostly "no downisdes at all", but this one introduces caching.