### PR TITLE
fix minitest warnings by using assert_nil

### DIFF
--- a/test/json_reference/reference_test.rb
+++ b/test/json_reference/reference_test.rb
@@ -5,7 +5,7 @@ require "json_reference"
 describe JsonReference::Reference do
   it "expands a reference without a URI" do
     ref = reference("#/definitions")
-    assert_equal nil, ref.uri
+    assert_nil ref.uri
     assert_equal "#/definitions", ref.pointer
   end
 
@@ -17,7 +17,7 @@ describe JsonReference::Reference do
 
   it "expands just a root sign" do
     ref = reference("#")
-    assert_equal nil, ref.uri
+    assert_nil ref.uri
     assert_equal "#", ref.pointer
   end
 
@@ -29,13 +29,13 @@ describe JsonReference::Reference do
 
   it "normalizes pointers by adding a root sign prefix" do
     ref = reference("/definitions")
-    assert_equal nil, ref.uri
+    assert_nil ref.uri
     assert_equal "#/definitions", ref.pointer
   end
 
   it "normalizes pointers by stripping a trailing slash" do
     ref = reference("#/definitions/")
-    assert_equal nil, ref.uri
+    assert_nil ref.uri
     assert_equal "#/definitions", ref.pointer
   end
 

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -48,7 +48,7 @@ describe JsonSchema::Attributes do
     obj.schema = "schema"
 
     assert_raises NoMethodError do
-      assert_equal nil, obj[:copyable]
+      assert_nil obj[:copyable]
     end
 
     assert_equal "schema", obj[:schema]
@@ -71,8 +71,8 @@ describe JsonSchema::Attributes do
     obj = TestAttributes.new
 
     # should produce a nil value *without* a Ruby warning
-    assert_equal nil, obj.copyable
-    assert_equal nil, obj.schema
+    assert_nil obj.copyable
+    assert_nil obj.schema
   end
 
   class TestAttributes

--- a/test/json_schema_test.rb
+++ b/test/json_schema_test.rb
@@ -7,7 +7,7 @@ describe JsonSchema do
     it "succeeds" do
       schema, errors = JsonSchema.parse(schema_sample)
       assert schema
-      assert_equal nil, errors
+      assert_nil errors
     end
 
     it "returns errors on a parsing problem" do


### PR DESCRIPTION
fixes deprecation warnings like these:
```
DEPRECATED: Use assert_nil if expecting nil from /home/stefan/github/json_schema/test/json_schema_test.rb:10. This will fail in Minitest 6
```
This was part of another patch I'll post soon, but this is more likely a no brainer to be merged.