### PR TITLE
allow subtypes again when validating types (fixes #97)

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -526,7 +526,7 @@ module JsonSchema
 
     def validate_type(schema, data, errors, path)
       return true if !schema.type || schema.type.empty?
-      if schema.type_parsed.include?(data.class)
+      if schema.type_parsed.any? { |t| data.is_a?(t) }
         true
       else
         key = find_parent(schema)

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -38,6 +38,16 @@ describe JsonSchema::Validator do
     assert_valid
   end
 
+  it "validates sub-type successfully" do
+    pointer("#/definitions/app").merge!(
+      "type" => ["object"]
+    )
+    class SomeClass < Hash; end
+    @data_sample = SomeClass.new
+    @data_sample["name"] = "yayrails"
+    assert_valid
+  end
+
   it "validates type unsuccessfully" do
     pointer("#/definitions/app").merge!(
       "type" => ["object"]


### PR DESCRIPTION
This fault was originally introduced in d110c244b7d3d5121273fa52b636095edbdbac22.

Note that this actually makes no difference performance wise, as far as I can see: 
```
8,471 8,277 9,120  # without this patch
8,429 8,381 8,230  # with this patch
```
