### PR TITLE
Some performance improvements

### DIFF
--- a/lib/json_schema/attributes.rb
+++ b/lib/json_schema/attributes.rb
@@ -33,13 +33,16 @@ module JsonSchema
           # remove the reader already created by attr_accessor
           remove_method(attr)
 
-          need_dup = [Array, Hash, Set].include?(default.class)
+          if [Array, Hash, Set].include?(default.class)
+            default = default.freeze
+          end
+
           define_method(attr) do
             val = instance_variable_get(ref)
             if !val.nil?
               val
             else
-              need_dup ? default.class.new : default
+              default
             end
           end
         end

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -249,15 +249,14 @@ module JsonSchema
       # dependencies can either be simple or "schema"; only replace the
       # latter
       schema.dependencies.values.
-        select { |s| s.is_a?(Schema) }.
-        each { |s| yield s }
+        each { |s| yield s if s.is_a?(Schema) }
 
       # schemas contained inside hyper-schema links objects
       if schema.links
-        schema.links.map { |l| [l.schema, l.target_schema] }.
-          flatten.
-          compact.
-          each { |s| yield s }
+        schema.links.each { |l|
+          yield l.schema if l.schema
+          yield l.target_schema if l.target_schema
+        }
       end
     end
 

--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -248,8 +248,8 @@ module JsonSchema
 
       # dependencies can either be simple or "schema"; only replace the
       # latter
-      schema.dependencies.values.
-        each { |s| yield s if s.is_a?(Schema) }
+      schema.dependencies.
+        each_value { |s| yield s if s.is_a?(Schema) }
 
       # schemas contained inside hyper-schema links objects
       if schema.links

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -264,7 +264,7 @@ module JsonSchema
 
     def pointer
       if parent
-        parent.pointer + "/".freeze + fragment
+        (parent.pointer + "/".freeze + fragment).freeze
       else
         fragment
       end

--- a/lib/json_schema/schema.rb
+++ b/lib/json_schema/schema.rb
@@ -264,7 +264,7 @@ module JsonSchema
 
     def pointer
       if parent
-        parent.pointer + "/" + fragment
+        parent.pointer + "/".freeze + fragment
       else
         fragment
       end

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -26,7 +26,9 @@ describe JsonSchema::Attributes do
 
     hash = obj.copyable_default_with_object
     assert_equal({}, hash)
-    hash[:x] = 123
+    assert_raises(FrozenError) do
+      hash[:x] = 123
+    end
 
     # This is a check to make sure that the new object is not the same object
     # as the one that we just mutated above. When assigning defaults the module

--- a/test/json_schema/attribute_test.rb
+++ b/test/json_schema/attribute_test.rb
@@ -26,7 +26,13 @@ describe JsonSchema::Attributes do
 
     hash = obj.copyable_default_with_object
     assert_equal({}, hash)
-    assert_raises(FrozenError) do
+    ex = if defined?(FrozenError)
+           FrozenError
+         else
+           RuntimeError
+         end
+
+    assert_raises(ex) do
       hash[:x] = 123
     end
 


### PR DESCRIPTION
Hi,

We're using this gem at work (thank you for writing it!), and we're hitting some performance bottlenecks.  This PR aims to address *some* of them.  I apologize for not posting a benchmark.  We're loading a bunch of schemas on boot in our application, and I'm not sure what of that production data I can make public.

Each commit contains the result of the benchmarks I use against our production data.  Before these commits, loading our schemas would take 8.4 seconds and allocate over 30 million objects.  These commits reduce it to 4.5 seconds and about 5 million objects.

Of the 5 million remaining objects, [this line](https://github.com/brandur/json_schema/blob/b2cfdecac7c86432e459abbb0d44caa3d0b81eb0/lib/json_schema/schema.rb#L267) allocates 3.2 million objects.  I tried to cache that string, but it seems like the objects are mutable, so I couldn't get the cache invalidation to work correctly and it broke all the tests 😞.

I will work on getting a benchmark that I can share, but in the mean time I wanted to send these changes.

Thank you!