### PR TITLE
Add Ruby 2.6 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3.0
   - 2.4.1
   - 2.5
+  - 2.6
 
 script: bundle exec rake
 


### PR DESCRIPTION
Ruby 2.6 has been released recently so add it to the build matrix.