### PR TITLE
Add back Ruby 2.0 + 2.1 and update patch levels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 cache: bundler
 
 rvm:
-  - 2.2
-  - 2.3.0
-  - 2.4.1
-  - 2.5
-  - 2.6
+  - 2.0
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
+
+before_install:
+  # Bundler 2.0 killed support for old Rubies. Let's continue to build with
+  # them for now by using an old Bundler. It's plausible to just get rid of
+  # this if it becomes untenable/difficult to upkeep.
+  - gem install bundler -v '< 2'
 
 script: bundle exec rake
 


### PR DESCRIPTION
Adds back Ruby 2.0 and 2.1 to the build matrix, supported by making sure
we use a Bundler < 2.0 as suggested by Travis (it turns out that the 2.0
release broke *a lot* of projects):

https://docs.travis-ci.com/user/languages/ruby/#bundler-20

Also update patch levels to the latest for the Ruby versions that
support them [1].

[1] https://www.ruby-lang.org/en/downloads/releases/