### PR TITLE
Dereference external subschema with nested reference

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -105,6 +105,29 @@ module JsonSchema
         return false unless success
       end
 
+      # If the reference schema is a global reference
+      # then we'll need to manually expand any nested
+      # references.
+      if ref.uri
+        schema_children(new_schema) do |subschema|
+          next if subschema.expanded?
+          next unless subschema.reference
+
+          # Don't bother if the subschema points to the same
+          # schema as the reference schema.
+          next if ref_schema == subschema
+
+          subref = subschema.reference
+          # the subschema's ref is local to the file that the
+          # subschema is in; however since there's no URI
+          # the 'resolve_pointer' method would try to look it up
+          # within @schema. So: manually reconstruct the reference to
+          # use the URI of the parent ref.
+          subschema.reference = JsonReference::Reference.new("#{ref.uri}#{subref.pointer}")
+          dereference(subschema, ref_stack + [subref])
+        end
+      end
+
       # copy new schema into existing one while preserving parent, fragment,
       # and reference
       parent = ref_schema.parent

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -265,6 +265,57 @@ describe JsonSchema::ReferenceExpander do
     assert schema.expanded?
   end
 
+  it "expands a schema with a reference to an external schema with a nested property reference" do
+    sample1 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema",
+      "type" => "object",
+      "properties" => {
+        "foo" => {
+          "$ref" => "http://json-schema.org/b.json#/definitions/bar"
+        },
+        "foo2" => {
+          "$ref" => "http://json-schema.org/b.json#/definitions/baz"
+        }
+      }
+    }
+    schema1 = JsonSchema::Parser.new.parse!(sample1)
+    schema1.uri = "http://json-schema.org/a.json"
+
+    sample2 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema",
+      "type" => "object",
+      "definitions" => {
+        "bar" => {
+          "type" => "object",
+          "properties" => {
+            "omg" => {
+              "$ref" => "#/definitions/baz"
+            }
+          }
+        },
+        "baz" => {
+          "type" => "string",
+          "maxLength" => 3
+        }
+      }
+    }
+    schema2 = JsonSchema::Parser.new.parse!(sample2)
+    schema2.uri = "http://json-schema.org/b.json"
+
+    # Initialize a store and add our schema to it.
+    store = JsonSchema::DocumentStore.new
+    store.add_schema(schema1)
+    store.add_schema(schema2)
+
+    expander = JsonSchema::ReferenceExpander.new
+    expander.expand!(schema1, store: store)
+
+    # These both point to the same definition, 'baz', but
+    # 'foo' has a level of indirection.
+    assert_equal 3, schema1.properties["foo2"].max_length
+    assert_equal 3, schema1.properties["foo"].properties["omg"].max_length
+  end
+
   it "expands a reference to a link" do
     pointer("#/properties").merge!(
       "link" => { "$ref" => "#/links/0" }


### PR DESCRIPTION
Hi,

I ran into something that I think is a bug. The key thing is that `foo` points to `bar` (in a separate schema) which points to `baz` (in the second schema). After expanding the references, `bar` is expanded, but `baz` doesn't have the data I would expect it to, like so:

```
> schema1.inspect_schema
=> {:@expanded=>"true",
 :@type=>["\"object\""],
 :@properties=>
  {"foo"=>"http://json-schema.org/b.json#/definitions/bar [EXPANDED] [CLONE]",
   "foo2"=>"http://json-schema.org/b.json#/definitions/baz [EXPANDED] [CLONE]"}}

> schema2.inspect_schema
=> {:@expanded=>"true",
 :@definitions=>
  {"bar"=>{:@expanded=>"true", :@type=>["\"object\""], :@properties=>{"omg"=>"#/definitions/baz [COLLAPSED] [ORIGINAL]"}},
   "baz"=>{:@expanded=>"true", :@type=>["\"string\""], :@max_length=>"3"}},
 :@type=>["\"object\""]}
```

I added a loop to dereference subschemas, but this blew up, because the second reference was local to the second schema (so no URI in the reference). When the `resolve_pointer` method did its lookup, it would find a `nil` URI, and therefore attempt to resolve against the base schema `@schema` which in this case is the wrong one. By copying over the URI from the original reference, the lookup happens in the right place, but now I've got some infinite recursion going on.