### PR TITLE
Handle expansion for nested external property

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -117,14 +117,15 @@ module JsonSchema
           # schema as the reference schema.
           next if ref_schema == subschema
 
-          subref = subschema.reference
-          # the subschema's ref is local to the file that the
-          # subschema is in; however since there's no URI
-          # the 'resolve_pointer' method would try to look it up
-          # within @schema. So: manually reconstruct the reference to
-          # use the URI of the parent ref.
-          subschema.reference = JsonReference::Reference.new("#{ref.uri}#{subref.pointer}")
-          dereference(subschema, ref_stack + [subref])
+          if !subschema.reference.uri
+            # the subschema's ref is local to the file that the
+            # subschema is in; however since there's no URI
+            # the 'resolve_pointer' method would try to look it up
+            # within @schema. So: manually reconstruct the reference to
+            # use the URI of the parent ref.
+            subschema.reference = JsonReference::Reference.new("#{ref.uri}#{subschema.reference.pointer}")
+          end
+          dereference(subschema, ref_stack)
         end
       end
 

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -265,7 +265,62 @@ describe JsonSchema::ReferenceExpander do
     assert schema.expanded?
   end
 
-  it "expands a schema with a reference to an external schema with a nested property reference" do
+  it "expands a schema with a reference to an external schema with a nested external property reference" do
+    sample1 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema",
+      "type" => "object",
+      "properties" => {
+        "foo" => {
+          "$ref" => "http://json-schema.org/b.json#/definitions/bar"
+        }
+      }
+    }
+    schema1 = JsonSchema::Parser.new.parse!(sample1)
+    schema1.uri = "http://json-schema.org/a.json"
+
+    sample2 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema",
+      "type" => "object",
+      "definitions" => {
+        "bar" => {
+          "type" => "object",
+          "properties" => {
+            "omg" => {
+              "$ref" => "http://json-schema.org/c.json#/definitions/baz"
+            }
+          }
+        }
+      }
+    }
+    schema2 = JsonSchema::Parser.new.parse!(sample2)
+    schema2.uri = "http://json-schema.org/b.json"
+
+    sample3 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema",
+      "type" => "object",
+      "definitions" => {
+        "baz" => {
+          "type" => "string",
+          "maxLength" => 3
+        }
+      }
+    }
+    schema3 = JsonSchema::Parser.new.parse!(sample3)
+    schema3.uri = "http://json-schema.org/c.json"
+
+    # Initialize a store and add our schema to it.
+    store = JsonSchema::DocumentStore.new
+    store.add_schema(schema1)
+    store.add_schema(schema2)
+    store.add_schema(schema3)
+
+    expander = JsonSchema::ReferenceExpander.new
+    expander.expand!(schema1, store: store)
+
+    assert_equal 3, schema1.properties["foo"].properties["omg"].max_length
+  end
+
+  it "expands a schema with a reference to an external schema with a nested local property reference" do
     sample1 = {
       "$schema" => "http://json-schema.org/draft-04/hyper-schema",
       "type" => "object",


### PR DESCRIPTION
If you have a schema that has a reference to an object definition in a separate
schema, then there are three possibilities. The object properties in the second
schema could be:

1. actual properties
2. references to definitions within the same schema
3. references to definitions within a separate schema

When expanding references in the first schema, it would correctly handle both
cases 1 and 2, but not 3.

This adds a test for this use case, as well as the code to fix it.