### PR TITLE
Move development dependencies to `Gemfile` and constrain Byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,14 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
+
+gem 'ecma-re-validator', '~> 0.1'
+gem 'minitest', '~> 5.3'
+gem 'rake', '~> 10.3'
+gem 'simplecov'
+
+if RUBY_VERSION >= "2.3.0"
+  gem 'byebug'
+  gem 'pry'
+  gem 'pry-byebug'
+end

--- a/json_schema.gemspec
+++ b/json_schema.gemspec
@@ -11,13 +11,4 @@ Gem::Specification.new do |s|
 
   s.executables   = ["validate-schema"]
   s.files         = Dir["README.md", "LICENSE", "bin/*", "schemas/*", "{lib,test}/**/*.rb"]
-
-  s.add_development_dependency 'ecma-re-validator', '~> 0.1'
-  s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "rake", "~> 10.3"
-
-  s.add_development_dependency "byebug"
-  s.add_development_dependency "pry"
-  s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
It looks like a recent change has made Byebug only buildable on Ruby >
2.3.0. Here we move development dependencies out of the gemspec and
into a `Gemfile` and make sure to only try to install Byebug (and also
its debugging associates like Pry) on Ruby > 2.3.0.