### PR TITLE
Dereference schema children for subschemas without a reference

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -110,21 +110,23 @@ module JsonSchema
       # references.
       if ref.uri
         schema_children(new_schema) do |subschema|
-          next if subschema.expanded?
-          next unless subschema.reference
-
           # Don't bother if the subschema points to the same
           # schema as the reference schema.
           next if ref_schema == subschema
 
-          if !subschema.reference.uri
-            # the subschema's ref is local to the file that the
-            # subschema is in; however since there's no URI
-            # the 'resolve_pointer' method would try to look it up
-            # within @schema. So: manually reconstruct the reference to
-            # use the URI of the parent ref.
-            subschema.reference = JsonReference::Reference.new("#{ref.uri}#{subschema.reference.pointer}")
+          next if subschema.expanded?
+
+          if subschema.reference
+            if !subschema.reference.uri
+              # the subschema's ref is local to the file that the
+              # subschema is in; however since there's no URI
+              # the 'resolve_pointer' method would try to look it up
+              # within @schema. So: manually reconstruct the reference to
+              # use the URI of the parent ref.
+              subschema.reference = JsonReference::Reference.new("#{ref.uri}#{subschema.reference.pointer}")
+            end
           end
+
           dereference(subschema, ref_stack)
         end
       end


### PR DESCRIPTION
I made three separate commits in order to make this easier to review.

The first commit is just a pure re-arrangement, in order to make it easier to understand exactly what changed in the second commit.

The second commit adds a failing test for the `oneOf` scenario reported in #100. It fails with the following:

```
   1) Error:
JsonSchema::ReferenceExpander#test_0025_it handles oneOf with nested references to an external schema:
NoMethodError: undefined method `max_length' for nil:NilClass
    /Users/kytrinyx/code/json_schema/test/json_schema/reference_expander_test.rb:373:in `block (2 levels) in <top (required)>'
```
It also adds the fix.

Given that the edge case in #100 describes `oneOf` with a reference to an external schema, I also figured we should test it with a reference to a local schema. ✨It failed ✨.

The third commit adds a failing test for the "local schema" variant of `oneOf`, which gives the following error:

```
  1) Failure:
JsonSchema::ReferenceExpander#test_0026_it handles oneOf with nested references to a local schema [/Users/kytrinyx/code/json_schema/test/json_schema/reference_expander_test.rb:418]:
Expected: 3
  Actual: nil
```
It then fixes it.

Closes #100.