### PR TITLE
Prevent infinite loop on external ref to global schema

### DIFF
--- a/lib/json_schema/reference_expander.rb
+++ b/lib/json_schema/reference_expander.rb
@@ -93,6 +93,7 @@ module JsonSchema
       if !ref
         schema_children(ref_schema) do |subschema|
           next unless subschema.reference
+          next if ref_schema.uri == parent_ref.uri.to_s
 
           if !subschema.reference.uri && parent_ref
             subschema.reference = JsonReference::Reference.new("#{parent_ref.uri}#{subschema.reference.pointer}")

--- a/test/json_schema/reference_expander_test.rb
+++ b/test/json_schema/reference_expander_test.rb
@@ -454,6 +454,38 @@ describe JsonSchema::ReferenceExpander do
     assert_equal 3, schema1.properties["foo"].properties["bar"].one_of[1].properties["baz"].max_length
   end
 
+  it "does not infinitely recurse when external ref is local to its schema" do
+    sample1 = {
+      "id" => "http://json-schema.org/draft-04/schema#",
+      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "properties" => {
+        "additionalItems" => {
+          "anyOf" => [ { "$ref" => "#" } ]
+        }
+      }
+    }
+    schema1 = JsonSchema::Parser.new.parse!(sample1)
+    sample2 = {
+      "$schema" => "http://json-schema.org/draft-04/hyper-schema#",
+      "id" => "http://json-schema.org/draft-04/hyper-schema#",
+      "allOf" => [
+        { "$ref" => "http://json-schema.org/draft-04/schema#" }
+      ]
+    }
+    schema2 = JsonSchema::Parser.new.parse!(sample2)
+
+    store = JsonSchema::DocumentStore.new
+    expander = JsonSchema::ReferenceExpander.new
+
+    store.add_schema(schema1)
+    store.add_schema(schema2)
+
+    expander.expand!(schema2, store: store)
+
+    assert schema1.expanded?
+    assert schema2.expanded?
+  end
+
   it "it handles oneOf with nested references to a local schema" do
     sample1 = {
       "$schema" => "http://json-schema.org/draft-04/hyper-schema",


### PR DESCRIPTION
We manually construct a URI for the subschema's reference
using the parent ref. However, if the parent ref is the
same as ref schema's ref, then we've reached the end of
the road and should not further dereference the subschema's
children.

Fixes https://github.com/brandur/json_schema/issues/115