### PR TITLE
remove filename gate, fixes #118

### DIFF
--- a/bin/validate-schema
+++ b/bin/validate-schema
@@ -26,17 +26,15 @@ parser = OptionParser.new { |opts|
   end
 }
 
-if $0 == __FILE__
-  parser.parse!
-  success = command.run(ARGV.dup)
+parser.parse!
+success = command.run(ARGV.dup)
 
-  if success
-    command.messages.each { |m| $stdout.puts(m) }
-  elsif !command.errors.empty?
-    command.errors.each { |e| $stderr.puts(e) }
-    exit(1)
-  else
-    print_usage!
-    exit(1)
-  end
+if success
+  command.messages.each { |m| $stdout.puts(m) }
+elsif !command.errors.empty?
+  command.errors.each { |e| $stderr.puts(e) }
+  exit(1)
+else
+  print_usage!
+  exit(1)
 end

--- a/test/bin_test.rb
+++ b/test/bin_test.rb
@@ -1,12 +1,10 @@
 require "test_helper"
 
 #
-# The purpose of this sets of tests is just to include our Ruby executables
-# where possible so that we can get very basic sanity checks on their syntax
-# (which is something that of course Ruby can't do by default).
+# The purpose of this sets of tests is just to test our Ruby executables
+# where possible so that we can get very basic sanity checks on their syntax.
 #
-# We can do this without actually executing them because they're gated by `if
-# $0 == __FILE__` statements.
+# We can do this without actually executing them with a "ruby -c" call.
 #
 
 describe "executables in bin/" do
@@ -15,6 +13,7 @@ describe "executables in bin/" do
   end
 
   it "has roughly valid Ruby structure for validate-schema" do
-    load File.join(@bin_dir, "validate-schema")
+    IO.popen(["ruby", "-c", File.join(@bin_dir, "validate-schema")]) { |io| io.read }
+    assert_equal $?.exitstatus, 0, "Ruby syntax check failed; see error above"
   end
 end


### PR DESCRIPTION
Remove the filename gate in validate-schema and update the test to use ruby's
"-c" option to test the syntax.

The filename gate in validate-schema causes problems when it is installed as a
binstub via RubyGems, since in this case the program will not execute. This
has been described in #118, and it is detailed in https://github.com/rbenv/rbenv/issues/1178