### PR TITLE
Handle invalid date range in date format validation

### DIFF
--- a/lib/json_schema/validator.rb
+++ b/lib/json_schema/validator.rb
@@ -567,7 +567,7 @@ module JsonSchema
     end
 
     DEFAULT_FORMAT_VALIDATORS = {
-      "date" => ->(data) { data =~ DATE_PATTERN },
+      "date" => ->(data) { data =~ DATE_PATTERN && Date.parse(data) rescue false },
       "date-time" => ->(data) { data =~ DATE_TIME_PATTERN },
       "email" => ->(data) { data =~ EMAIL_PATTERN },
       "hostname" => ->(data) { data =~ HOSTNAME_PATTERN },

--- a/test/json_schema/validator_test.rb
+++ b/test/json_schema/validator_test.rb
@@ -718,6 +718,14 @@ describe JsonSchema::Validator do
     refute_valid
   end
 
+  it "validates date format when month and day exceed valid range unsuccessfully" do
+    pointer("#/definitions/app/definitions/owner").merge!(
+      "format" => "date"
+    )
+    data_sample["owner"] = "2014-24-60"
+    refute_valid
+  end
+
   it "validates date-time format successfully" do
     pointer("#/definitions/app/definitions/owner").merge!(
       "format" => "date-time"


### PR DESCRIPTION
We are using `format: date` in a project and we realized that it allows for dates that exceed the valid range of a month or day.
e.g. `2012-60-82` is considered a valid date in the current implementation.

This PR validates the date using the `Date` class to ensure the value is within the correct range.

We based this solution on an implemetation in a different JSON schema library:
 https://github.com/ruby-json-schema/json-schema/blob/765e6d8fdbfdaca1a42fa743f4621e757f9f6a03/lib/json-schema/attributes/formats/date.rb#L13